### PR TITLE
fix(security): close DataSourceRead connection_config exposure to non-admin users (T2B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ Post-v1.1.0 commits on `master`. No version bump yet.
 - **CHANGELOG, UNIFIED-SPEC, installer button URLs (`ad44a86`, 2026-04-18):** CHANGELOG entries added for commits `301c4f3`/`c433beb`/`9c1d98b`/`23f0655` and moved into `[1.1.0]` where they belong. Stale "30s ceiling" corrected to "600s ceiling (D-FAIL-12)". UNIFIED-SPEC §17 test count updated to 432; priority 9 entry (Rule 9 deliverables) added; D-PROC-1 decision record added; §18 process criteria added; §19 Verification Log added at position 0. All 4 installer buttons in `docs/index.html` corrected from `/raw/master/` to `/releases/download/v1.1.0/`.
 
 ### Security
+- **T2B — `DataSourceRead.connection_config` credential exposure closed (2026-04-20):** `GET /datasources/` was accessible to all STAFF-and-above users and returned the full `DataSourceRead` schema, which included `connection_config: dict`. That JSONB blob contains every credential stored for the data source — REST API keys, bearer tokens, OAuth `client_secret`, ODBC `connection_string`, IMAP passwords — all readable by any authenticated staff member, not just admins who manage the sources.
+
+  **The fix:** `connection_config` removed from `DataSourceRead`. A new `DataSourceAdminRead` subclass adds it back; `DataSourceAdminRead` is used only by `POST /datasources/` and `PATCH /datasources/{id}`, both of which are already gated at `require_role(UserRole.ADMIN)`. `GET /datasources/` continues to use `DataSourceRead` (redacted) for all callers including admins.
+
+  **Schema audit checklist:** `docs/T2B-SCHEMA-AUDIT-2026-04-20.md` — every response schema in `backend/app/schemas/` swept for credentials, connection strings, tokens, OAuth client secrets, internal-only fields. One additional finding (`ServiceAccountCreated.api_key`) confirmed as intentional show-once pattern (admin-only POST, DB stores hash only, never returned on GET). Connector config schemas (`RestApiConfig`, `ODBCConfig`) confirmed as input-only; their credential fields are transitively covered by the `DataSourceRead` redaction.
+
+  **Tests added** in `backend/tests/test_datasources.py` (4 new, zero skips):
+  - `test_staff_list_datasources_no_connection_config` — STAFF GET `/datasources/` → all sensitive fields absent from every item in the response
+  - `test_admin_list_datasources_no_connection_config` — ADMIN GET `/datasources/` → `connection_config` absent (redacted shape applies to all callers on list)
+  - `test_admin_create_datasource_returns_connection_config` — ADMIN POST `/datasources/` → `connection_config` present and matches submitted config
+  - `test_admin_update_datasource_returns_connection_config` — ADMIN PATCH `/datasources/{id}` → `connection_config` present and matches updated config
+
+  **Scope limit (T2B closure note):** Runtime exposure of `connection_config` to non-admin users: **CLOSED**. Storage exposure (plaintext in DB, accessible via pg_dump, snapshots, Postgres superuser): **OPEN — tracked in Tier 6 of the remediation plan**. ENG-001 must not be marked fully closed until Tier 6 (at-rest encryption) lands.
+
 - **Info-leak follow-up — 404-vs-403 status code disclosure closed across the dept-scoped surface (2026-04-20):** Started as a narrow fix for the two child-before-parent handlers filed in `docs/FINDING-2026-04-19-info-leak-child-before-parent.md`. During the fix a codebase-wide audit surfaced the **same 404-vs-403 disclosure at the parent level** — every handler that loads a RecordsRequest or Document by path-param ID and then raises 403 via `require_department_scope` had the identical status-code side channel. Scope was expanded to cover all of it. Owner directive 2026-04-20: "wrong move" to leave the broader pattern for a future PR.
 
   **The pattern:** fake `request_id` → 404 "Request not found"; real `request_id` in another dept → 403. An authenticated cross-department caller could distinguish a leaked/guessed UUID's status via the difference. Same shape for documents, letters, flags.

--- a/backend/app/datasources/router.py
+++ b/backend/app/datasources/router.py
@@ -17,7 +17,7 @@ from app.auth.dependencies import require_role
 from app.database import get_async_session
 from app.models.document import DataSource, Document, DocumentChunk, IngestionStatus, SourceType
 from app.models.user import User, UserRole
-from app.schemas.document import DataSourceCreate, DataSourceRead, DataSourceUpdate, IngestionStats
+from app.schemas.document import DataSourceAdminRead, DataSourceCreate, DataSourceRead, DataSourceUpdate, IngestionStats
 
 async def _double_fetch_hashes(
     connector, first_source_path: str, data_key: str | None
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/datasources", tags=["datasources"])
 
-@router.post("/", response_model=DataSourceRead, status_code=201)
+@router.post("/", response_model=DataSourceAdminRead, status_code=201)
 async def create_datasource(data: DataSourceCreate, session: AsyncSession = Depends(get_async_session), user: User = Depends(require_role(UserRole.ADMIN))):
     existing = await session.execute(select(DataSource).where(DataSource.name == data.name))
     if existing.scalar_one_or_none():
@@ -120,7 +120,7 @@ async def list_datasources(session: AsyncSession = Depends(get_async_session), u
         output.append(data)
     return output
 
-@router.patch("/{source_id}", response_model=DataSourceRead)
+@router.patch("/{source_id}", response_model=DataSourceAdminRead)
 async def update_datasource(source_id: uuid.UUID, data: DataSourceUpdate, session: AsyncSession = Depends(get_async_session), user: User = Depends(require_role(UserRole.ADMIN))):
     source = await session.get(DataSource, source_id)
     if not source:

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -21,10 +21,10 @@ class DataSourceCreate(BaseModel):
 
 
 class DataSourceRead(BaseModel):
+    """Redacted datasource shape — safe for non-admin roles. connection_config omitted."""
     id: uuid.UUID
     name: str
     source_type: SourceType
-    connection_config: dict
     sync_schedule: str | None = None
     schedule_enabled: bool = True
     next_sync_at: datetime | None = None
@@ -47,6 +47,11 @@ class DataSourceRead(BaseModel):
     @classmethod
     def _default_health_status(cls, v):
         return v if v is not None else "healthy"
+
+
+class DataSourceAdminRead(DataSourceRead):
+    """Full datasource shape including connection_config. Returned only by admin-gated endpoints."""
+    connection_config: dict
 
 
 class DataSourceUpdate(BaseModel):

--- a/backend/tests/test_datasources.py
+++ b/backend/tests/test_datasources.py
@@ -96,3 +96,72 @@ async def test_health_status_healthy_default(client: AsyncClient, admin_token: s
     assert src is not None
     assert src["health_status"] == "healthy"
     assert src["active_failure_count"] == 0
+
+
+# --- T2B response-shape redaction tests ---
+SENSITIVE_FIELDS = {"connection_config", "api_key", "token", "password", "client_secret", "database_url"}
+
+
+@pytest.mark.asyncio
+async def test_staff_list_datasources_no_connection_config(client: AsyncClient, admin_token: str, staff_token: str):
+    """GET /datasources/ returns DataSourceRead (redacted) — connection_config absent for staff."""
+    await client.post(
+        "/datasources/",
+        json={"name": f"redact-test-{uuid.uuid4().hex[:8]}", "source_type": "rest_api",
+              "connection_config": {"api_key": "secret-value", "base_url": "https://example.com"}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.get("/datasources/", headers={"Authorization": f"Bearer {staff_token}"})
+    assert resp.status_code == 200
+    for src in resp.json():
+        for field in SENSITIVE_FIELDS:
+            assert field not in src, f"Sensitive field '{field}' found in staff list response"
+
+
+@pytest.mark.asyncio
+async def test_admin_list_datasources_no_connection_config(client: AsyncClient, admin_token: str):
+    """GET /datasources/ returns redacted shape even for admins — connection_config absent."""
+    resp = await client.get("/datasources/", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    for src in resp.json():
+        assert "connection_config" not in src, "connection_config must not appear in list response"
+
+
+@pytest.mark.asyncio
+async def test_admin_create_datasource_returns_connection_config(client: AsyncClient, admin_token: str):
+    """POST /datasources/ returns DataSourceAdminRead — connection_config present for admin."""
+    config = {"api_key": "secret-value", "base_url": "https://example.com"}
+    resp = await client.post(
+        "/datasources/",
+        json={"name": f"admin-create-{uuid.uuid4().hex[:8]}", "source_type": "rest_api",
+              "connection_config": config},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "connection_config" in data, "Admin create response must include connection_config"
+    assert data["connection_config"] == config
+
+
+@pytest.mark.asyncio
+async def test_admin_update_datasource_returns_connection_config(client: AsyncClient, admin_token: str):
+    """PATCH /datasources/{id} returns DataSourceAdminRead — connection_config present for admin."""
+    create_resp = await client.post(
+        "/datasources/",
+        json={"name": f"admin-patch-{uuid.uuid4().hex[:8]}", "source_type": "rest_api",
+              "connection_config": {"api_key": "old-secret"}},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert create_resp.status_code == 201
+    source_id = create_resp.json()["id"]
+
+    new_config = {"api_key": "new-secret", "base_url": "https://updated.example.com"}
+    patch_resp = await client.patch(
+        f"/datasources/{source_id}",
+        json={"connection_config": new_config},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert patch_resp.status_code == 200
+    data = patch_resp.json()
+    assert "connection_config" in data, "Admin update response must include connection_config"
+    assert data["connection_config"] == new_config

--- a/docs/T2B-SCHEMA-AUDIT-2026-04-20.md
+++ b/docs/T2B-SCHEMA-AUDIT-2026-04-20.md
@@ -1,0 +1,74 @@
+# T2B Schema Audit — Sensitive Field Sweep
+
+Date: 2026-04-20
+Scope: Every user-visible response schema in `backend/app/schemas/` and inline router schemas.
+Audited by: dev (initial sweep); required auditor verification under CLAUDE.md Hard Rule 1.
+
+Sensitive field list: `connection_config`, `api_key`, `token`, `password`, `client_secret`,
+`database_url`, `connection_string`, `client_secret`.
+
+---
+
+## Findings
+
+### FIXED — `DataSourceRead.connection_config` exposed to STAFF
+
+**File:** `backend/app/schemas/document.py`
+**Route:** `GET /datasources/` (`require_role(UserRole.STAFF)`)
+**Field:** `connection_config: dict`
+**Risk:** Any authenticated STAFF user could read the full connection config for every
+data source, including stored credentials inside the JSONB blob (REST API keys, bearer
+tokens, OAuth client secrets, ODBC connection strings).
+**Fix:** `connection_config` removed from `DataSourceRead`. New `DataSourceAdminRead`
+subclass adds it back; used only by admin-gated `POST /datasources/` and
+`PATCH /datasources/{id}`.
+**Status:** FIXED in this PR.
+
+### FIXED (transitively) — Connector credential fields in `connection_config` JSONB
+
+**Files:**
+- `backend/app/schemas/connectors/rest_api.py` — `api_key`, `token`, `client_secret`, `password`
+- `backend/app/schemas/connectors/odbc.py` — `connection_string`
+
+**Risk:** These fields are input schemas that get serialized as JSONB into
+`DataSource.connection_config`. They were reachable by STAFF via the `DataSourceRead`
+exposure above.
+**Fix:** Covered by the `DataSourceRead` redaction above. The connector config schemas
+themselves are input-only; they are not used as response schemas.
+**Status:** FIXED transitively by the `DataSourceRead` fix.
+
+---
+
+## Clean — No Action Required
+
+| Schema file | Fields reviewed | Finding |
+|---|---|---|
+| `schemas/document.py` — `DocumentRead` | All fields | None — no credentials |
+| `schemas/document.py` — `DocumentChunkRead` | `token_count` | Chunk word-count integer, not a credential |
+| `schemas/service_account.py` — `ServiceAccountRead` | All fields | None — `api_key_hash` not exposed, hash not returned |
+| `schemas/service_account.py` — `ServiceAccountCreated` | `api_key` | By design: shown once on admin-only `POST /service-accounts/`. DB stores `api_key_hash` only. Never returned on GET. Acceptable show-once pattern. |
+| `schemas/analytics.py` | All fields | None |
+| `schemas/audit.py` | All fields | None |
+| `schemas/city_profile.py` | All fields | None |
+| `schemas/department.py` | All fields | None |
+| `schemas/exemption.py` | All fields | None |
+| `schemas/fee_schedule.py` | All fields | None |
+| `schemas/model_registry.py` | All fields | None |
+| `schemas/notifications.py` | All fields | None |
+| `schemas/request.py` | All fields | None |
+| `schemas/search.py` | All fields | None |
+| `schemas/sync_failure.py` | All fields | None |
+| `schemas/user.py` | All fields | None — `UserSelfUpdate` blocks role/dept writes; no credential fields in UserRead |
+| `schemas/connectors/rest_api.py` | Input schema only | Credential fields present but never used as response schema |
+| `schemas/connectors/odbc.py` | Input schema only | `connection_string` present but never used as response schema |
+
+---
+
+## Out of Scope for T2B (documented, not deferred without tracking)
+
+- **At-rest encryption of `data_sources.connection_config`:** DB, pg_dump, snapshot, and
+  Postgres superuser access still exposes plaintext credentials. This is Tier 6 in the
+  remediation plan (`docs/REMEDIATION-PLAN-2026-04-19.md`). ENG-001 must not be marked
+  fully closed until Tier 6 lands.
+- **T2B closure note:** Runtime exposure of `connection_config` to non-admin users: **CLOSED**.
+  Storage exposure (at rest in DB): **OPEN — tracked in Tier 6**.


### PR DESCRIPTION
## Summary

- Splits `DataSourceRead` into a redacted base schema (no `connection_config`) and `DataSourceAdminRead` (adds it back)
- `GET /datasources/` now returns the redacted shape for all callers; `POST` and `PATCH` (both admin-gated) return `DataSourceAdminRead`
- Adds 4 response-shape assertion tests covering staff list, admin list, admin create, and admin update
- Adds `docs/T2B-SCHEMA-AUDIT-2026-04-20.md` — full schema sweep checklist across all `backend/app/schemas/` files

## Scope limit

Runtime exposure of `connection_config` to non-admin users: **CLOSED**.
Storage exposure (plaintext at rest in DB, pg_dump, snapshots): **OPEN — tracked in Tier 6**.
ENG-001 must not be marked fully closed until Tier 6 lands.

## Test plan

- [ ] CI backend: 461 + 4 new tests pass (465 total)
- [ ] `test_staff_list_datasources_no_connection_config` — STAFF GET returns no sensitive fields
- [ ] `test_admin_list_datasources_no_connection_config` — ADMIN GET also returns no `connection_config`
- [ ] `test_admin_create_datasource_returns_connection_config` — ADMIN POST includes `connection_config`
- [ ] `test_admin_update_datasource_returns_connection_config` — ADMIN PATCH includes `connection_config`
- [ ] CI frontend: vitest + build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)