### PR TITLE
[INITIAL] Add scripts/verify-release.sh (Phase 1)

### DIFF
--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# civicrecords-ai/scripts/verify-release.sh — Phase 1 release gate.
+#
+# Read-only verification. Checks:
+#   1. Data sovereignty — delegates to scripts/verify-sovereignty.sh
+#   2. Version lockstep across 4 surfaces:
+#      - backend/pyproject.toml     (version = "X")
+#      - frontend/package.json      ("version": "X")
+#      - CHANGELOG.md               (top "## [X]" heading)
+#      - docs/UNIFIED-SPEC.md       ("Current release | vX" table row)
+#   3. Required Rule 9 doc artifacts present on disk
+#
+# Exit 0 when every check passes; exit 1 on any failure. Never writes.
+# Does NOT modify scripts/verify-sovereignty.sh or its .ps1 twin.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+FAILED=0
+pass() { printf '  \033[0;32m[PASS]\033[0m %s\n' "$*"; }
+fail() { printf '  \033[0;31m[FAIL]\033[0m %s\n' "$*" >&2; FAILED=1; }
+info() { printf '\n\033[1;34m%s\033[0m\n' "$*"; }
+
+# --- 1. sovereignty guard ----------------------------------------------------
+info "1. data sovereignty"
+if [ ! -x scripts/verify-sovereignty.sh ] && [ ! -f scripts/verify-sovereignty.sh ]; then
+    fail "scripts/verify-sovereignty.sh missing"
+else
+    if bash scripts/verify-sovereignty.sh; then
+        pass "sovereignty guard passed"
+    else
+        fail "sovereignty guard failed"
+    fi
+fi
+
+# --- 2. version lockstep (4 surfaces) ----------------------------------------
+info "2. version lockstep"
+
+declare -a SURFACES=()
+declare -a VALUES=()
+
+# extract <label> <file> <grep-ere> <sed-ere>
+extract() {
+    local label="$1" file="$2" gregex="$3" sedexpr="$4"
+    if [ ! -f "$file" ]; then
+        SURFACES+=("$label")
+        VALUES+=("<missing>")
+        return 0
+    fi
+    local val
+    val=$(grep -oE "$gregex" "$file" 2>/dev/null | head -1 | sed -E "$sedexpr" || true)
+    if [ -z "${val:-}" ]; then
+        val="<no match>"
+    fi
+    SURFACES+=("$label")
+    VALUES+=("$val")
+}
+
+extract "backend/pyproject.toml" "backend/pyproject.toml" \
+    '^version[[:space:]]*=[[:space:]]*"[^"]+"' \
+    's/^version[[:space:]]*=[[:space:]]*"([^"]+)"/\1/'
+
+extract "frontend/package.json" "frontend/package.json" \
+    '"version"[[:space:]]*:[[:space:]]*"[^"]+"' \
+    's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+
+extract "CHANGELOG.md" "CHANGELOG.md" \
+    '^##[[:space:]]*\[[0-9]+\.[0-9]+\.[0-9]+\]' \
+    's/^##[[:space:]]*\[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/'
+
+extract "docs/UNIFIED-SPEC.md (Current release)" "docs/UNIFIED-SPEC.md" \
+    'Current release[[:space:]]*\|[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+' \
+    's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
+
+for i in "${!SURFACES[@]}"; do
+    printf '      %-40s %s\n' "${SURFACES[$i]}" "${VALUES[$i]}"
+done
+
+UNIQ=$(printf '%s\n' "${VALUES[@]}" | sort -u \
+    | grep -vE '^<(no match|missing)>$' | wc -l | tr -d ' ')
+if [ "$UNIQ" -eq 1 ]; then
+    pass "one unique version across ${#SURFACES[@]} surface(s)"
+else
+    fail "version drift: $UNIQ unique values across ${#SURFACES[@]} surface(s)"
+fi
+
+# --- 3. required docs --------------------------------------------------------
+info "3. required docs present"
+for f in README.md CHANGELOG.md CONTRIBUTING.md LICENSE .gitignore docs/index.html; do
+    if [ -f "$f" ]; then
+        pass "$f"
+    else
+        fail "missing: $f"
+    fi
+done
+
+# --- summary -----------------------------------------------------------------
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    printf '\033[0;32mVERIFY-RELEASE: PASSED\033[0m\n'
+    exit 0
+else
+    printf '\033[0;31mVERIFY-RELEASE: FAILED\033[0m\n'
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Phase 1 release gate for civicrecords-ai. Adds a single new file, `scripts/verify-release.sh`, as the release-generic verification entrypoint alongside the existing domain-specific `scripts/verify-sovereignty.sh`. No existing files modified — sovereignty script and its `.ps1` twin intentionally untouched.

## Checks implemented

1. Data sovereignty — delegates to `scripts/verify-sovereignty.sh` and propagates its exit code
2. Version lockstep across 4 surfaces: `backend/pyproject.toml`, `frontend/package.json`, `CHANGELOG.md` top heading, `docs/UNIFIED-SPEC.md` "Current release | vX" table row
3. Rule 9 baseline docs present

`set -euo pipefail`. Exit 0 on all-green; exit 1 on any failure. Never writes.

## Validation

Ran locally on the branch HEAD. **Script exits `1` — this is the expected and correct behavior.** Version lockstep check passed (all 4 surfaces at `1.2.0`). Rule 9 docs check passed (all 6 artifacts present). The sovereignty guard correctly propagates `[FAIL] API bound to local port` from `verify-sovereignty.sh`, which reflects the current local runtime state of the Docker stack — not a defect in either script.

**Script behavior correct. Sovereignty precondition not green in the current runtime. No out-of-scope remediation applied.**

## Out of scope

- No modifications to `scripts/verify-sovereignty.sh` — intentional: "sovereignty" is load-bearing domain semantics (municipal data residency), not naming drift.
- No modifications to `scripts/verify-sovereignty.ps1`.
- No backend, frontend, or docs source edits.
- No CI workflow changes.
- No pre-push hook installed.
- No `.ps1` twin added for `verify-release.sh`.
- No touches to `UNIFIED-SPEC.md`, `USER-MANUAL.md`, `README.md`, or `SUPERVISOR.md` content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)