### PR TITLE
release: switch to civiccore v0.1.0 release artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Post-v1.2.0 commits on `master`. No version bump yet.
 
 ### Added
-- New external dependency on `civiccore` (pinned to `git+https://github.com/CivicSuite/civiccore.git@e7c5570` during Phase 1; will become a versioned wheel pin before v1.3.0).
+- New external dependency on `civiccore`, now pinned to the versioned `v0.1.0` GitHub release wheel rather than a Git SHA.
 - Backend migrations now run the `civiccore` shared-schema baseline before records' own chain via `backend/alembic/env.py`. See [ADR-0003](https://github.com/CivicSuite/civicsuite/blob/main/docs/architecture/ADR-0003-civiccore-alembic-baseline-strategy.md) for the rationale and gate contract.
 - 3 migration gate tests at `backend/tests/test_civiccore_migration_gates.py` covering fresh-install, v1.2.x upgrade, and reapplication idempotency scenarios.
 
 ### Changed
-- `Dockerfile.backend` now installs `git` during image build so pip can resolve the temporary `git+https` civiccore dependency.
+- `Dockerfile.backend` no longer installs `git`; the backend now resolves `civiccore` from a versioned wheel URL and no longer needs Git at image-build time.
 - 14 records migrations updated to use `civiccore.migrations.guards.idempotent_*` helpers, making them safe to re-apply on databases where the civiccore baseline has already created the shared tables (users, service_accounts, audit_log, data_sources, documents, document_chunks, model_registry, exemption_rules, connector_templates, departments, system_catalog, city_profile, notification_templates, prompt_templates, sync_run_log, sync_failures).
 
 ## [1.2.0] - 2026-04-23

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,11 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential libpq-dev curl \
-    git \
     && rm -rf /var/lib/apt/lists/*
-# git is required by pip to fetch the civiccore dependency from
-# git+https://github.com/CivicSuite/civiccore.git@<sha> until civiccore
-# 0.1.0 is published to PyPI. Once published, this line can drop git.
 
 COPY backend/pyproject.toml .
 RUN pip install --no-cache-dir ".[dev]"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ bash install.sh
 
 ### Phase 1 migration layer
 
-CivicRecords AI backend installs `civiccore` (the shared CivicSuite schema + migration runtime) as a dependency. During the Phase 1 transition period `civiccore` is pinned by git+SHA rather than PyPI version; see `backend/pyproject.toml`. Because of this, the backend Docker build requires `git` inside the image (already wired in `Dockerfile.backend`).
+CivicRecords AI backend installs `civiccore` (the shared CivicSuite schema + migration runtime) as a dependency. During the release-hardening window before PyPI publication, `backend/pyproject.toml` points at the versioned `v0.1.0` GitHub release wheel rather than a Git SHA. This keeps the dependency reproducible without requiring `git` inside the backend image.
 
 Migrations run in two layers: `civiccore` first (creates/updates the 16 shared tables), then this repo's Alembic chain on top. See [ADR-0003](https://github.com/CivicSuite/civicsuite/blob/main/docs/architecture/ADR-0003-civiccore-alembic-baseline-strategy.md) for the full gate contract.
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "python-jose[cryptography]>=3.5.0",
     "passlib[bcrypt]>=1.7.4",
     "celery>=5.6.0",
-    "civiccore @ git+https://github.com/CivicSuite/civiccore.git@e7c5570",
+    "civiccore @ https://github.com/CivicSuite/civiccore/releases/download/v0.1.0/civiccore-0.1.0-py3-none-any.whl",
     "croniter>=2.0.0",
     "redis>=5.0.0,<8.0.0",
     "httpx>=0.28.0",


### PR DESCRIPTION
## Summary

Release-hardening step 2 for Phase 1.

This branch updates CivicRecords AI to consume the published `civiccore v0.1.0` GitHub release artifact instead of the temporary Git SHA dependency.

## Changes

- pins `civiccore` to the live `v0.1.0` release wheel in `backend/pyproject.toml`
- removes the temporary `git` dependency from `Dockerfile.backend`
- updates README and CHANGELOG to reflect the released artifact path and the two-layer migration model

## Scope

This PR is intentionally limited to the downstream release-hardening switch.

Out of scope:
- any new `civiccore` feature work
- Gate 2 fixture upgrades
- `civicrecords-ai v1.3.0` release cut

## Dependency

This PR depends on the published `civiccore v0.1.0` release now being live:
- wheel: `civiccore-0.1.0-py3-none-any.whl`
- sdist: `civiccore-0.1.0.tar.gz`
- checksums: `SHA256SUMS.txt`

## Notes

Phase 1 was previously merged on `master` at `0cd5a7a`. This PR is the release-hardening follow-up that moves the backend off the temporary Git SHA pin and onto the published release artifact.
