### PR TITLE
chore(build): add .dockerignore to exclude dev artifacts from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Build context exclusions for civicrecords-ai
+#
+# Why: every service in docker-compose.yml uses `build.context: .`. Without
+# this file Docker BuildKit ships everything in the repo as build context
+# to each `docker compose build`, including dev artifacts that no service
+# Dockerfile references. This wastes time, bloats the build context, and
+# in the frontend's case has been a hard build failure when npm leaves
+# transient `.bin/.<random>` symlinks in node_modules — see PR description
+# for the captured failure mode and before/after context-size numbers.
+#
+# CRITICAL — DO NOT exclude `backend/tests/fixtures/`. The Gate 2 test at
+# `backend/tests/test_civiccore_migration_gates.py::test_gate2_upgrade_from_v1_2`
+# reads `schema_v1_2_0.sql` from inside the api container at test time.
+# The api Dockerfile copies `backend/tests` into the image. Excluding the
+# fixtures directory would silently break Gate 2 on the next image rebuild.
+
+# --- Git / VCS / GitHub ---
+.git
+.gitignore
+.gitattributes
+.github
+
+# --- Node / frontend ---
+**/node_modules
+frontend/dist
+frontend/build
+**/.npm
+**/.yarn
+
+# --- Python / backend ---
+**/.venv
+**/venv
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/htmlcov
+**/.coverage
+backend/dist
+backend/build
+
+# --- Local environment files (allow .env.example for onboarding/docs) ---
+**/.env
+**/.env.*
+!**/.env.example
+
+# --- Editor / OS / tooling ---
+.vscode
+.idea
+.claude
+**/.DS_Store
+**/Thumbs.db
+
+# --- Logs / runtime artifacts ---
+*.log
+*.pid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Post-v1.2.0 commits on `master`. No version bump yet.
 ### Changed
 - `Dockerfile.backend` no longer installs `git`; the backend now resolves `civiccore` from a versioned wheel URL and no longer needs Git at image-build time.
 - 14 records migrations updated to use `civiccore.migrations.guards.idempotent_*` helpers, making them safe to re-apply on databases where the civiccore baseline has already created the shared tables (users, service_accounts, audit_log, data_sources, documents, document_chunks, model_registry, exemption_rules, connector_templates, departments, system_catalog, city_profile, notification_templates, prompt_templates, sync_run_log, sync_failures).
+- Build performance: added `.dockerignore` at repo root to exclude `.git`, `node_modules`, `__pycache__`, virtualenvs, and other dev artifacts from docker build context. Image build size and time reduced — see PR description for exact delta. Frontend build also fixed: without `.dockerignore`, transient npm `.bin/.<random>` symlinks in `node_modules` could fail the BuildKit "load build context" step with `invalid file request`.
 
 ## [1.2.0] - 2026-04-23
 


### PR DESCRIPTION
Adds `.dockerignore` at repo root + companion CHANGELOG entry. Two commits on the branch — file change and the doc note — kept separate per the "prefer new commit over amend" Hard Rule.

## Why

Without `.dockerignore`, every service in `docker-compose.yml` (api, worker, beat, frontend) ships the entire repo as build context. For api/worker/beat the BuildKit smart-COPY keeps the impact small (2.41 MB transferred). For frontend it's a HARD BUILD FAILURE because npm leaves transient `.bin/.<random>` symlinks in `node_modules`, and BuildKit refuses them with `invalid file request`. Surfaced 2026-04-24 during the Step 2b env bring-up.

## Build context size — measured

| Service | BEFORE (no .dockerignore) | AFTER | Delta |
|---|---|---|---|
| `api` | 2.41 MB (build OK) | **1.22 MB** | -49% |
| `frontend` | 241.93 MB **(BUILD FAILED** on `frontend/node_modules/cross-spawn/node_modules/.bin/.node-which-HWSxeuyK`) | **0.88 MB** | -99.6%, broken→working |

Both AFTER builds: `docker compose --progress=plain build <svc> --no-cache`, exit 0.

The frontend before/after is correctness, not just performance — the build cannot complete on a clean clone whenever any local npm install leaves transient `.bin/.<random>` entries behind.

## Critical preservation — `backend/tests/fixtures/` NOT excluded

The Gate 2 test (`test_civiccore_migration_gates.py::test_gate2_upgrade_from_v1_2`) loads `backend/tests/fixtures/schema_v1_2_0.sql` at runtime from inside the api container. `Dockerfile.backend` includes `COPY backend/tests ./tests`, so fixtures must survive the build context. `.dockerignore` excludes only dev artifacts; fixtures and tests proper are untouched. **Verified: post-add Gate 2 PASS (0.61s) against the rebuilt api image.**

## Local verification (single pass against rebuilt image)

```
$ docker compose run --rm api python -m pytest tests/test_civiccore_migration_gates.py -v
3 passed in 3.53s (gate1 0.97s, gate2 0.61s, gate3 1.33s)

$ cd frontend && npm test
Test Files  9 passed (9), Tests  36 passed (36), Duration 4.25s

$ docker compose run --rm api python -m pytest tests --tb=line
620 passed, 145 warnings in 735.85s (0:12:15), exit 0

$ bash scripts/verify-release.sh
Sovereignty: 8 passed / 1 pre-existing warning / 0 failed
Version lockstep: 1.2.0 across 4 surfaces
Rule-9 doc artifacts: all 6 present
VERIFY-RELEASE: PASSED
```

## Files changed (2 files, +59 / 0)

- `.dockerignore` (NEW, 58 lines) — exclusions for `.git`, `.github`, `**/node_modules`, `frontend/dist`, `frontend/build`, `**/.venv`, `**/__pycache__`, `**/.pytest_cache`, `**/.mypy_cache`, `**/.ruff_cache`, `**/htmlcov`, `**/.coverage`, `backend/dist`, `backend/build`, `**/.env`, `**/.env.*` with `!**/.env.example` re-include for onboarding/docs, editor dirs, OS dirs, logs/pids. Includes a CRITICAL header comment noting `backend/tests/fixtures/` is intentionally NOT excluded so Gate 2's runtime fixture load survives image rebuilds.
- `CHANGELOG.md` (+1 line under `[Unreleased]` > Changed) — operator-facing build-perf note that v1.3.0 release notes will cite.

## Out of scope (separate PRs / batches)

- No version bump. v1.3.0 cut is Step 3, separate batch.
- No `[1.3.0]` section header in CHANGELOG — only an Unreleased entry.
- No audit-lite skill changes (the user pulled that update earlier).
- No Step 2b followups; Gate 2 is closed at master `3825cc4`.
- No changes to any other config/source file in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)