### PR TITLE
[THROWAWAY — DO NOT MERGE] live-fire test of ruff CI gate (PR #34)

### DIFF
--- a/backend/tests/test_ruff_gate_livefire_throwaway.py
+++ b/backend/tests/test_ruff_gate_livefire_throwaway.py
@@ -1,0 +1,11 @@
+"""Throwaway file for the live-fire test of the ruff CI gate added in PR #34.
+
+This file deliberately contains a single ruff violation (F401: unused import)
+to confirm the new `ruff (lint)` CI job fails CI when violations are present.
+
+DO NOT MERGE. After CI confirms the ruff job fails as expected, the parent
+PR is closed without merge and this file goes away with the deleted branch.
+
+Sprint log entry will record the outcome.
+"""
+import os  # noqa: ruff-test-violation-do-not-fix-this-is-the-point


### PR DESCRIPTION
Live-fire test of the ruff CI gate added in #34 (now merged at `1a19a9e`). This PR contains a single deliberate `F401` violation (`import os` with no usage in `backend/tests/test_ruff_gate_livefire_throwaway.py`).

**Expected:** ruff (lint) CI job FAILS. All other jobs (backend pytest, frontend, T2C smoke) pass since the throwaway file doesn't break runtime.

**After CI confirms ruff fails:** I'll close this PR without merge and delete the branch. The unmerged commit goes away with the branch.

Per dev directive: live-fire test of new gate after #33 merge. Sprint log will record the outcome.