### PR TITLE
fix(frontend): belt-and-suspenders for DataSources.test.tsx label-association flake (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes since v1.3.0.
 ### Removed
 
 ### Fixed
+- Frontend: belt-and-suspenders for the rare `DataSources.test.tsx` label-association flake observed once on PR #29's CI (issue #30). The test body now uses async `findByLabelText` instead of sync `getByLabelText`, layered on top of the prior `openWizard()` async wait (commit `e898319`). 30/30 filtered + 10/10 full-file pass post-fix. Other tests in the file using sync queries left untouched per scope-lock; if any flake later, file follow-up issues. Closes #30.
 
 ### Security
 

--- a/frontend/src/pages/DataSources.test.tsx
+++ b/frontend/src/pages/DataSources.test.tsx
@@ -62,8 +62,14 @@ describe("DataSources — Add Source wizard accessibility + validation (T4C)", (
   it("associates the Source Name label with its input via htmlFor/id", async () => {
     await openWizard();
 
-    const nameInput = screen.getByLabelText(/source name/i) as HTMLInputElement;
-    // getByLabelText only returns a match when label → input is programmatically linked.
+    // openWizard() awaits findByLabelText for the same input (commit
+    // e898319), but a portal-mounted Dialog can re-render between that
+    // resolution and a sync query in the test body — observed once on
+    // PR #29's CI (issue #30), passed on rerun and consistently locally.
+    // Belt-and-suspenders: the test body also uses findBy* so a transient
+    // re-mount during the assertion phase doesn't fail the test.
+    const nameInput = (await screen.findByLabelText(/source name/i)) as HTMLInputElement;
+    // findByLabelText only returns a match when label → input is programmatically linked.
     expect(nameInput).toBeInTheDocument();
     expect(nameInput.id).toBe("ds-name");
     expect(nameInput.getAttribute("aria-required")).toBe("true");


### PR DESCRIPTION
## Closes [#30](https://github.com/scottconverse/civicrecords-ai/issues/30)

Pre-flight Bug fix #2 of the Phase 2 sprint. Belt-and-suspenders fix for the rare label-association flake observed once on PR #29's CI.

## Investigation

The `openWizard()` helper at lines 53-59 of `DataSources.test.tsx` was already hardened in commit `e898319` (Tier 5 flake-fix) — it awaits `findByLabelText` for the same input so callers can use sync queries safely. So the prior fix was already in place when PR #29's CI flaked.

The flake is **not reproducible on Windows local**:
- 50 runs of the filtered test against pre-fix master: 50/50 PASS
- Full file 1x against pre-fix master: 10/10 PASS

Likely cause: Linux-CI-runner contention or a rare React unmount-remount cycle between openWizard's `findByLabelText` resolution and the test body's sync `getByLabelText`.

## Fix

Single-line change at the named-failing test (line 64):
`screen.getByLabelText(...)` → `await screen.findByLabelText(...)`

Inline comment documents the layered defense.

**Other tests in the file using sync queries are NOT touched** per scope-lock. If any sibling flakes later, file follow-up issues.

## Post-fix verification

- 30 runs of the now-fixed filtered test: **30/30 PASS**, exit 0 each.
- Full-file 1x: **10/10 PASS**, no sibling regressions.

## Sprint context

- Audit tier: Tier 2.
- Closing the dual scope: issue #30 documented the flake honestly. This PR addresses the test-body fragility; the underlying CI-runner contention can't be fixed from records-ai code.
- No mid-PR scope creep. 4 other sync queries in the file untouched; if any flake later, separate issues.

## Refs

- Closes [#30](https://github.com/scottconverse/civicrecords-ai/issues/30)
- Sister deferrals (active sprint): [#31](https://github.com/scottconverse/civicrecords-ai/issues/31)
- Prior flake-fix: commit `e898319`

🤖 Generated with [Claude Code](https://claude.com/claude-code)