### PR TITLE
release: civicrecords-ai v1.4.0 — Phase 2 LLM integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Changes since v1.3.0.
+No unreleased changes.
+
+## [1.4.0] - 2026-04-25
+
+Phase 2 LLM extraction release. Records-AI now consumes `civiccore` v0.2.0 as a versioned dependency. The LLM provider abstraction, prompt-template engine, and model registry have moved to `civiccore.llm`; records-AI keeps thin re-export shims so existing call sites work unchanged.
+
+### Operator upgrade notes (v1.3.0 → v1.4.0)
+
+- **civiccore dependency:** the `civiccore` wheel pin advances from v0.1.0 to v0.2.0. The new wheel is published at `https://github.com/CivicSuite/civiccore/releases/download/v0.2.0/civiccore-0.2.0-py3-none-any.whl`. Reinstall is automatic on `pip install -e .[dev]` from a fresh clone; existing operator deployments need to rebuild the API image (`docker compose build api`).
+- **Migration:** running `alembic upgrade head` on a v1.3.0 database now applies one new civiccore-side revision (`civiccore_0002_llm`) plus one new records-side revision (`020_phase2_consumer_app_backfill`). The civiccore revision ALTERs `prompt_templates`: renames `name` → `template_name`, adds `consumer_app VARCHAR(100) NOT NULL DEFAULT 'civiccore'`, adds `is_override BOOLEAN NOT NULL DEFAULT false`, replaces `UNIQUE(name)` with `UNIQUE(consumer_app, template_name, version)`. The records-side revision is data-only — it sets `consumer_app='civicrecords-ai'` + `is_override=true` on rows that records-AI shipped (it does not change the schema).
+- **Backwards compatibility:** API URL paths and admin permissions are unchanged. Code that imported `from app.models.prompts import PromptTemplate` or `from app.schemas.model_registry import ...` continues to work — the records-AI modules are now thin re-export shims around `civiccore.llm.{templates,registry}`. Code that read `pt.name` on a `PromptTemplate` instance must update to `pt.template_name`.
+- **Generated artifacts:** `docs/openapi.json` and `frontend/src/generated/api.ts` were regenerated to reflect the admin router's swap to civiccore Pydantic types. Frontend hot-reload will pick this up on rebuild; existing API clients that hard-coded the old `$ref` schema names need to regenerate from the new spec.
+- **Test infrastructure:** Gate 2 fixture (`backend/tests/fixtures/schema_v1_3_0.sql`) replaces the prior v1.2.0 fixture. Operators do not interact with this; it is for CI's migration gate suite.
 
 ### Added
 - Phase 2 Step 1: scratch scope worksheet for the `civiccore.llm` extraction at `docs/architecture/phase2-civiccore-llm-scope.md` (records-ai side). Inventories the modules moving to civiccore (model_registry ORM/schemas/router, prompt_templates ORM, Ollama client, context manager, prompt-injection sanitizer), the modules staying in records-ai (FOIA-specific exemption reviewer, multimodal OCR extractor, response-letter pipeline), the override-resolution algorithm for prompt templates (records-ai instance overrides → records-ai code overrides → civiccore defaults; no silent fallback), the `string.Template` engine choice, and the registry-decorator provider-registration mechanism. Feeds ADR-0004 (Step 2) and the Step 3 implementation against civiccore main.
@@ -25,14 +37,8 @@ Changes since v1.3.0.
 - Build/CI: ruff is now a required CI check (`.github/workflows/ci.yml` job `ruff (lint)`); 82 pre-existing violations cleaned up (70 auto-fixed, 6 manually fixed including 4 E402 import-order fixes and 1 F841 unused-variable removal, 4 retained as inline `# noqa: E402` with rule-ID + justification). `scripts/verify-release.sh` gains a step 4 that runs `ruff check` against the api container. Closes #33.
 - Docs: regenerated all binary doc artifacts (`README.{docx,pdf}`, `README-FULL.pdf`, `USER-MANUAL.{docx,pdf}`, `README.txt`, `docs/civicrecords-ai-manual.{docx,pdf}`, `docs/UNIFIED-SPEC.docx`, `docs/CivicRecordsAI-UnifiedSpec-v3.1.docx`) to match the v1.3.0 source state. Both Python (`docs/generate_pdfs.py`, `docs/generate_docx.py`) and Node (`docs/generate-deliverables.js`, `docs/generate-manual-{pdf,docx}.js`, `docs/generate-unified-spec-docx.js`) generator chains were re-run; binaries updated only — no generator-source or markdown-source changes. Closes #31. Hard Rule 0 four-format sync restored.
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 - Frontend: belt-and-suspenders for the rare `DataSources.test.tsx` label-association flake observed once on PR #29's CI (issue #30). The test body now uses async `findByLabelText` instead of sync `getByLabelText`, layered on top of the prior `openWizard()` async wait (commit `e898319`). 30/30 filtered + 10/10 full-file pass post-fix. Other tests in the file using sync queries left untouched per scope-lock; if any flake later, file follow-up issues. Closes #30.
-
-### Security
 
 ## [1.3.0] - 2026-04-25
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
 
-APP_VERSION = "1.3.0"
+APP_VERSION = "1.4.0"
 
 _INSECURE_SECRETS = {"CHANGE-ME", "CHANGE-ME-generate-with-openssl-rand-hex-32", ""}
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "civicrecords-ai"
-version = "1.3.0"
+version = "1.4.0"
 description = "Open-source AI-powered open records support for American cities"
 requires-python = ">=3.12"
 license = "Apache-2.0"

--- a/docs/UNIFIED-SPEC.md
+++ b/docs/UNIFIED-SPEC.md
@@ -8,7 +8,7 @@ April 13, 2026
 | Status | Canonical — verified against repository at commit head |
 | Supersedes | All prior spec versions (v2.0, v2.2, v3.0, v3.0.1) |
 | Repository | github.com/scottconverse/civicrecords-ai |
-| Current release | v1.3.0 (April 24, 2026) — versions aligned across all files |
+| Current release | v1.4.0 (April 25, 2026) — versions aligned across all files |
 | Test suite | 617 automated backend tests + 36 frontend tests — all passing; GitHub Actions CI-verified (run 24853147133 on commit `d556904`) |
 | Method | GitHub API crawl of repo structure, README, CHANGELOG, config files, module directories, and in-repo RECONCILIATION doc |
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "CivicRecords AI",
     "description": "AI-powered open records support for American cities",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "paths": {
     "/auth/jwt/login": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "civicrecords-admin",
-  "version": "1.1.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "civicrecords-admin",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "civicrecords-admin",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Cuts records-ai v1.4.0. Version-bump-only commit; all Phase 2 Step 5 code is already on master via PR #42.

v1.4.0 ships:
- civiccore v0.2.0 wheel pin (was v0.1.0)
- Phase 2 LLM integration: records-ai \`app.llm\`, \`app.models.{prompts,document}\`, \`app.schemas.model_registry\`, \`app.admin.router\`, \`app.ingestion.embedder\` all wire through \`civiccore.llm\`
- Migration 020 (data-only backfill of \`prompt_templates.consumer_app\` after civiccore_0002_llm ALTERs the table)
- Gate 2 fixture upgraded from v1.2.0 to v1.3.0 baseline; column-drift assertion whitelists Phase 2 prompt_templates delta
- Generated artifacts (\`docs/openapi.json\`, \`frontend/src/generated/api.ts\`) regenerated to match swapped admin-router types

## Version surfaces (5 files updated)

| File | Change |
|---|---|
| \`backend/pyproject.toml\` | 1.3.0 → 1.4.0 |
| \`backend/app/config.py\` \`APP_VERSION\` | 1.3.0 → 1.4.0 |
| \`frontend/package.json\` + lock | 1.3.0 → 1.4.0 (project's own version, not deps) |
| \`docs/UNIFIED-SPEC.md\` Current release | v1.3.0 → v1.4.0 |
| \`CHANGELOG.md\` | \`[Unreleased]\` cut to \`[1.4.0] - 2026-04-25\` with operator upgrade notes; Unreleased reset |

## Verification

- [x] Local \`bash scripts/verify-release.sh\` — **PASSED** (sovereignty 8/1/0, version lockstep 1 unique across 4 surfaces, 6 required docs present, ruff 0 violations)
- [ ] CI green (pending)

## Process after merge

1. Tag \`v1.4.0\` from master
2. Push tag → triggers \`.github/workflows/release.yml\`
3. Verify GitHub release publishes with assets + Latest mark

## Scope locks honored

No source/test logic changes. No civiccore changes. No CivicSuite umbrella changes. No Step 7 (compat matrix). No Step 8 (sprint closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)