### PR TITLE
test: stabilize data source wizard dialog test

### DIFF
--- a/frontend/src/pages/DataSources.test.tsx
+++ b/frontend/src/pages/DataSources.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { render, screen, act, fireEvent, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import DataSources, { formatNextRun } from "./DataSources";
 
@@ -41,15 +42,14 @@ describe("DataSources — Add Source wizard accessibility + validation (T4C)", (
 
   afterEach(() => {
     vi.restoreAllMocks();
+    cleanup();
   });
 
   async function openWizard() {
     render(<DataSources token="test-token" />);
     // Wait past the loading skeleton
     const addBtn = await screen.findByRole("button", { name: /add source/i });
-    await act(async () => {
-      fireEvent.click(addBtn);
-    });
+    await userEvent.click(addBtn);
     // The wizard is a base-ui Dialog mounted into a portal. The click
     // returning does not guarantee the portal subtree is in the DOM yet;
     // on slow/contended runners (CI) the sync getByLabelText/getByRole


### PR DESCRIPTION
## Summary
- stabilize the DataSources dialog accessibility test after the post-merge CI flake
- add explicit Testing Library cleanup and use userEvent for the Base UI dialog trigger

## Verification
- npm test => 36 passed
- npm run build => passed, existing bundle-size warning only
- scripts/verify-release.sh => VERIFY-RELEASE: PASSED
