### PR TITLE
Use provenance wrapper in release workflows

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -57,7 +57,7 @@ jobs:
           ref: main
           path: .tmp-civiccore
       - name: Verify adversarial release provenance fixtures
-        run: python -m civiccore.release_provenance --fixtures-dir .tmp-civiccore/tests/fixtures/release_provenance
+        run: python scripts/verify-release-provenance.py --fixtures-dir .tmp-civiccore/tests/fixtures/release_provenance
       - name: Install cosign
         if: ${{ inputs.fixtures_only != 'true' }}
         uses: sigstore/cosign-installer@v4.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           path: .tmp-civiccore
 
       - name: Verify adversarial release provenance fixtures
-        run: python -m civiccore.release_provenance --fixtures-dir .tmp-civiccore/tests/fixtures/release_provenance
+        run: python scripts/verify-release-provenance.py --fixtures-dir .tmp-civiccore/tests/fixtures/release_provenance
 
   build-windows-installer:
     name: Build Windows installer (unsigned)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `release-attestation.json`, verify it before publication, and upload the
   attestation plus bundle alongside the installer and checksum. No existing
   release, tag, or release notes were modified by this change.
+- Release-preflight fixture checks invoke the local provenance wrapper script so
+  Actions logs stay free of Python module re-execution warnings.
 
 ## [1.4.10] - 2026-05-03
 


### PR DESCRIPTION
## Summary
- switch release/preflight fixture checks from `python -m civiccore.release_provenance` to the local wrapper script
- remove the Python module re-execution warning from post-merge dry-run evidence
- document the warning cleanup in the changelog

## Not Release-Class Work
- no tags deleted, recreated, or pushed
- no GitHub releases created or modified
- no existing release notes edited
- no attestation generated against any real existing release

## Verification
- `python scripts\verify-release-provenance.py --fixtures-dir C:\Users\scott\OneDrive\Desktop\Claude\civiccore\tests\fixtures\release_provenance` — PASS, all 9 fixtures
- `git diff --check` — PASS
- `bash scripts/verify-release.sh` — PASS, sovereignty passed with known warnings, version lockstep/docs/ruff green