### PR TITLE
fix(ci): release.yml YAML parse error in release-notes HEREDOC (closes audit TEST-022)

### DIFF
--- a/.github/release-notes-v15-template.md
+++ b/.github/release-notes-v15-template.md
@@ -1,0 +1,16 @@
+
+## Verify release provenance
+
+```bash
+cosign verify-blob release-attestation.json \
+  --bundle release-attestation.json.bundle \
+  --certificate-identity "https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/${TAG}" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+sha256sum -c CivicRecordsAI-${VERSION}-Setup.exe.sha256
+python scripts/verify-release-provenance.py "${TAG}" \
+  --repo "${REPO}" \
+  --attestation release-attestation.json \
+  --bundle release-attestation.json.bundle \
+  --artifacts-dir .
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,25 +243,10 @@ jobs:
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          REPO="${GITHUB_REPOSITORY}"
+          TAG="${GITHUB_REF_NAME}"
           cp .github/release-notes-preamble.md release-notes.md
-          cat >> release-notes.md <<EOF
-
-## Verify release provenance
-
-\`\`\`bash
-cosign verify-blob release-attestation.json \\
-  --bundle release-attestation.json.bundle \\
-  --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/${{ github.ref_name }}" \\
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-
-sha256sum -c CivicRecordsAI-${VERSION}-Setup.exe.sha256
-python scripts/verify-release-provenance.py "${{ github.ref_name }}" \\
-  --repo "${{ github.repository }}" \\
-  --attestation release-attestation.json \\
-  --bundle release-attestation.json.bundle \\
-  --artifacts-dir .
-\`\`\`
-EOF
+          envsubst < .github/release-notes-v15-template.md >> release-notes.md
 
       - name: Create draft release
         env:


### PR DESCRIPTION
## Summary

Fixes audit TEST-022: `.github/workflows/release.yml` failed YAML parsing before jobs could start because the release-notes HEREDOC body was unindented relative to the surrounding `run: |` block.

## Scanner Error

```text
yaml.scanner.ScannerError: while scanning a simple key
  in ".github/workflows/release.yml", line 251, column 1
could not find expected ':'
  in ".github/workflows/release.yml", line 252, column 1
```

## Affected Range

`.github/workflows/release.yml` lines 247-264: the `cat >> release-notes.md <<EOF` body was at column 1, so YAML exited the block scalar and treated the fenced code marker as a malformed top-level key.

## Fix

- Extracted the markdown release-notes body to `.github/release-notes-v15-template.md`.
- Replaced the indentation-sensitive HEREDOC with `envsubst < .github/release-notes-v15-template.md >> release-notes.md`.
- Kept the release provenance command content equivalent, using `GITHUB_REPOSITORY`, `GITHUB_REF_NAME`, and the derived `VERSION` shell variables.

## Verification

```powershell
python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"
```

Result: no error.

## Audit Link

Closes TEST-022 from `audit-civicsuite-2026-05-09/04-test-deepdive.md`.

## Scope Boundary

Only `.github/workflows/release.yml` and the extracted release-notes template changed. No product code, release artifacts, tags, or other workflows changed.
