### PR TITLE
fix(ci): run release verification on Linux, keep Windows job to installer build only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,22 +49,21 @@ jobs:
       - name: Verify adversarial release provenance fixtures
         run: python scripts/verify-release-provenance.py --fixtures-dir .tmp-civiccore/tests/fixtures/release_provenance
 
-  build-windows-installer:
-    name: Build Windows installer (unsigned)
-    runs-on: windows-latest
+  verify-release-linux:
+    name: Verify release on Linux (compose + tests)
+    runs-on: ubuntu-latest
     needs: preflight
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up Python for release provenance preflight
+      - name: Set up Python for release verification
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install CivicCore release-provenance helper
-        shell: bash
         run: python -m pip install "git+https://github.com/CivicSuite/civiccore.git@main"
 
       - name: Synthesize hermetic .env for release verification
@@ -87,8 +86,25 @@ jobs:
           EOF
 
       - name: Run release verification
-        shell: bash
         run: bash scripts/verify-release.sh
+
+  build-windows-installer:
+    name: Build Windows installer (unsigned)
+    runs-on: windows-latest
+    needs: [preflight, verify-release-linux]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python for release provenance preflight
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install CivicCore release-provenance helper
+        shell: bash
+        run: python -m pip install "git+https://github.com/CivicSuite/civiccore.git@main"
 
       - name: Install Inno Setup
         run: choco install innosetup -y


### PR DESCRIPTION
## Summary
- Splits release verification into a new `verify-release-linux` job on `ubuntu-latest`.
- Keeps the Windows job focused on building, attesting, and uploading the Inno Setup installer.
- Leaves `scripts/verify-release.sh` unchanged and runs it exactly once on Linux, where Docker Compose can pull and run the Linux service images.

## Why
The tag-triggered v1.5.0 release run got past the YAML parse fix and then failed inside the Windows installer job while running `bash scripts/verify-release.sh`:

```text
no matching manifest for windows(10.0.26100)/amd64 in the manifest list entries
```

That failure happens because the release verifier provisions the Docker Compose stack for Postgres, Redis, Ollama, and the API. Those compose/runtime checks require Linux containers. The Windows job is still required for the unsigned Inno Setup `.exe`, so the release workflow now separates those responsibilities.

## Verification
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8'))"`
- `bash scripts/verify-release.sh`
  - recovery gates passed
  - secret scan passed
  - compose sovereignty guard passed
  - 633 backend tests passed
  - 36 frontend tests passed
  - 4 Playwright user-flow tests passed
  - runtime install proof passed with `civicrecords-ai==1.5.0` and `civiccore==1.0.1`
  - final `VERIFY-RELEASE: PASSED`

## Scope
No product code changed. No `scripts/verify-release.sh` changes. No other workflows changed.
