### PR TITLE
fix(ci): dump container logs from verify-release.sh when compose health-check fails

### DIFF
--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -48,6 +48,32 @@ else
         pass "compose runtime provisioned"
     else
         fail "compose runtime failed to become healthy"
+        echo ""
+        echo "============================================"
+        echo "  Container logs (compose health-check failed)"
+        echo "============================================"
+        echo ""
+        echo "## docker compose ps"
+        docker compose ps || true
+        echo ""
+        echo "## docker compose logs --no-color --tail 100 api"
+        docker compose logs --no-color --tail 100 api || true
+        echo ""
+        echo "## docker compose logs --no-color --tail 50 postgres"
+        docker compose logs --no-color --tail 50 postgres || true
+        echo ""
+        echo "## docker compose logs --no-color --tail 30 redis"
+        docker compose logs --no-color --tail 30 redis || true
+        echo ""
+        echo "## docker compose logs --no-color --tail 30 ollama"
+        docker compose logs --no-color --tail 30 ollama || true
+        echo ""
+        echo "## .env shape (secrets redacted)"
+        grep -v -E '^(JWT_SECRET|FIRST_ADMIN_PASSWORD|ENCRYPTION_KEY)=' .env || true
+        echo "## (secret vars elided)"
+        echo ""
+        echo "============================================"
+        echo ""
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Dumps Docker Compose state and container logs when the release health check cannot bring the runtime up.
- Includes `docker compose ps`, API logs, dependency service logs, and a redacted `.env` shape.
- Does not change product code or the release verifier's pass/fail criteria.

## Why
The v1.5.0 tag-triggered release run [25642434043](https://github.com/CivicSuite/civicrecords-ai/actions/runs/25642434043) failed with only this high-level signal:

```text
[FAIL] compose runtime failed to become healthy
```

The downstream sovereignty failures were misleading because the API had already exited, but `verify-release.sh` did not print the API container logs needed to identify why.

## New dump format
```text
============================================
  Container logs (compose health-check failed)
============================================

## docker compose ps
...

## docker compose logs --no-color --tail 100 api
...

## docker compose logs --no-color --tail 50 postgres
...

## docker compose logs --no-color --tail 30 redis
...

## docker compose logs --no-color --tail 30 ollama
...

## .env shape (secrets redacted)
...
## (secret vars elided)

============================================
```

## Verification
- `bash -n scripts/verify-release.sh`
- `bash scripts/verify-release.sh`
  - recovery gates passed
  - secret scan passed
  - compose sovereignty guard passed
  - 633 backend tests passed
  - 36 frontend tests passed
  - 4 Playwright user-flow tests passed
  - runtime install proof passed
  - final `VERIFY-RELEASE: PASSED`

## Scope
Diagnostic-only PR. No backend source changes. No speculative fix bundled.
