### PR TITLE
fix(ci): release workflow FIRST_ADMIN_EMAIL must not use .local (special-use reserved domain)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           DATABASE_URL=postgresql+asyncpg://civicrecords:civicrecords@postgres:5432/civicrecords
           JWT_SECRET=${JWT_SECRET}
           ENCRYPTION_KEY=${ENCRYPTION_KEY}
-          FIRST_ADMIN_EMAIL=admin@ci.local
+          FIRST_ADMIN_EMAIL=admin@example.org
           FIRST_ADMIN_PASSWORD=${ADMIN_PW}
           OLLAMA_BASE_URL=http://ollama:11434
           REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
## Summary
- Changes the release workflow's hermetic `FIRST_ADMIN_EMAIL` from `admin@ci.local` to `admin@example.org`.
- Keeps the fix scoped to workflow environment shape only.
- Does not touch backend/product code or email-validator behavior.

## Why
The v1.5.0 diagnostic release run [25644005159](https://github.com/CivicSuite/civicrecords-ai/actions/runs/25644005159) exposed the real API startup failure after PR #72 added container-log dumping:

```text
pydantic_core._pydantic_core.ValidationError: 1 validation error for AdminUserCreate
email
  value is not a valid email address: The part after the @-sign is a special-use or reserved name that cannot be used with email. [type=value_error, input_value='admin@ci.local', input_type=str]
```

The diagnostic was made possible by PR #72's compose-failure container-log dump. `email-validator` rejects `.local` as a special-use/reserved domain under RFC 6762. `admin@example.org` uses the RFC 2606 example domain, is validator-accepted, and never resolves to a real operational mailbox.

## Verification
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8'))"`
- `grep`/PowerShell scan confirmed no remaining `admin@ci.local` matches and one `FIRST_ADMIN_EMAIL=admin@example.org` match.
- `bash scripts/verify-release.sh`
  - recovery gates passed
  - secret scan passed
  - compose sovereignty guard passed
  - 633 backend tests passed
  - 36 frontend tests passed
  - 4 Playwright user-flow tests passed
  - runtime install proof passed
  - final `VERIFY-RELEASE: PASSED`

## Scope
One-line workflow env fix only. No backend source changes.
