### PR TITLE
fix(ci): remove secret pointer env names from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,6 @@ jobs:
           DATABASE_URL=postgresql+asyncpg://civicrecords:civicrecords@postgres:5432/civicrecords
           ENCRYPTION_KEY=${ENCRYPTION_KEY}
           FIRST_ADMIN_EMAIL=admin@example.org
-          JWT_SECRET_FILE=/run/secrets/jwt_secret
-          FIRST_ADMIN_PASSWORD_FILE=/run/secrets/first_admin_password
           CIVICRECORDS_SECRET_DIR=./data/secrets
           OLLAMA_BASE_URL=http://ollama:11434
           REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
## Summary

This is the bounded v1.6.0 tag-move recovery fix for release run 25716971823.

The tag-triggered Release workflow failed in `Verify release on Linux (compose + tests)` because the workflow's hermetic `.env` synthesis still wrote the two B2 pointer env names:

```text
JWT_SECRET_FILE=/run/secrets/jwt_secret
FIRST_ADMIN_PASSWORD_FILE=/run/secrets/first_admin_password
[FAIL] .env exposes a JWT_SECRET* or FIRST_ADMIN_PASSWORD* name; run install.sh/install.ps1 to migrate B2 secrets into Docker secret files
JWT_SECRET_FILE=/run/secrets/jwt_secret
FIRST_ADMIN_PASSWORD_FILE=/run/secrets/first_admin_password
[FAIL] api container env exposes a JWT_SECRET* or FIRST_ADMIN_PASSWORD* name (B2 literal directive grep)
VERIFY-RELEASE: FAILED
```

This PR removes those two stale CI-only `.env` lines. Product code is unchanged; the app already defaults to `/run/secrets/jwt_secret` and `/run/secrets/first_admin_password` without needing env pointer names.

## Verification

```text
python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8'))"
# no output / no error
```

```text
rg -n "JWT_SECRET_FILE|FIRST_ADMIN_PASSWORD_FILE" .github/workflows/release.yml
# no matches
```

```text
C:\Program Files\Git\bin\bash.exe scripts/verify-release.sh
RECOVERY-GATES: PASSED
SECRET-SCAN: PASSED (511 tracked file(s) scanned)
[PASS] compose runtime provisioned
[PASS] api container env hides JWT_SECRET and FIRST_ADMIN_PASSWORD (literal directive grep)
DATA SOVEREIGNTY: PASSED WITH WARNINGS
[PASS] sovereignty guard passed
[PASS] one unique version across 4 surface(s)
[PASS] required docs present
[PASS] ruff: 0 violations
[PASS] pytest collect-only: 638 test(s)
[PASS] pytest full suite: 638 passed
[PASS] frontend vitest
[PASS] frontend production build
[PASS] Playwright user-flow tests
RUNTIME-INSTALL-PROOF: health {'status': 'ok', 'version': '1.6.0'}
RUNTIME-INSTALL-PROOF: PASSED
[PASS] runtime install proof
VERIFY-RELEASE: PASSED
```

## 5-lens self-audit

- Engineering: pass. Diff is restricted to `.github/workflows/release.yml` and removes only the two stale B2 pointer env names that caused release run 25716971823 to fail.
- UX: pass. No user-facing UI/copy changes.
- Tests: pass. Local `scripts/verify-release.sh` passed after the workflow fix and includes the literal B2 grep proof.
- Docs: pass. This is a CI-only recovery fix; the release/handoff docs will record the failed run and tag-move recovery after the release workflow clears.
- QA: pass. YAML parses, workflow grep has no pointer env matches, and the verifier exercises the same release path locally.
Artifact-state: pass. Existing `.tmp-browser-qa-*` scratch dirs remain untracked and out of scope; no product or doc artifacts changed in this PR.
Post-push propagation: pass. Branch HEAD is `119eaea833d77365497c4368507bb29a8be4c4af`; PR body cites this run's current failure and the local verification performed after the fix.
