### PR TITLE
chore: narrow unqualified macOS support claims to honest current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ No open-source tool exists for the **responder side** of open records at the mun
 
 ### Requirements
 
-- **Docker Desktop** (Windows 10/11, macOS 13+) or **Docker Engine** (Linux)
+- **Docker Desktop** (Windows 10/11) or **Docker Engine** (Linux). Windows-only currently; macOS support pending lifecycle certification (Docker Desktop on macOS 13+ runs the script path but is not lifecycle-certified).
 - **8+ CPU cores**, **32 GB RAM**, **50 GB free disk space**
 - No internet connection required after initial setup
 
@@ -43,7 +43,7 @@ No open-source tool exists for the **responder side** of open records at the mun
 >
 > 1. **Windows double-click installer (T5E, UNSIGNED).** A signed build is a future release — this one is not. The unsigned installer is published on every release tag at `releases/download/<tag>/CivicRecordsAI-<version>-Setup.exe` along with a SHA-256 checksum for independent verification. On first run Windows SmartScreen shows **"Windows protected your PC — Unknown publisher."** This is expected. Click **More info → Run anyway** to proceed. See [installer/windows/README.md](installer/windows/README.md) for the full SmartScreen walkthrough and checksum-verify steps. The installer bundles the repo snapshot, runs a prereq check (Docker Desktop, WSL 2 + Virtual Machine Platform, 32 GB RAM floor, optional host Ollama), then runs `install.ps1` (via `installer\windows\launch-install.ps1`). `install.ps1` **auto-pulls `nomic-embed-text` and auto-pulls the Gemma 4 tag you select in the picker** (default `gemma4:e4b`) — expect several minutes on first run — and seeds the T5B baseline datasets.
 >
-> 2. **Script-based install (Linux / macOS, and Windows if you prefer CLI).** The scripts below configure and start the Docker Compose stack. They do **not** install Docker, WSL, or any other system prerequisites — those must already be present. `install.ps1` / `install.sh` both ship the 4-model Gemma 4 picker, auto-pull the selected LLM plus `nomic-embed-text`, and auto-seed the baseline datasets on first boot.
+> 2. **Script-based install (Linux / macOS — not lifecycle-certified — and Windows if you prefer CLI).** Windows-only currently; macOS support pending lifecycle certification. The scripts below configure and start the Docker Compose stack on macOS and Linux as a non-certified path, and on Windows as a CLI alternative. They do **not** install Docker, WSL, or any other system prerequisites — those must already be present. `install.ps1` / `install.sh` both ship the 4-model Gemma 4 picker, auto-pull the selected LLM plus `nomic-embed-text`, and auto-seed the baseline datasets on first boot.
 >
 > **Two shortcuts, two flows.** The Windows installer creates **separate** Start Menu entries for the two operations — don't confuse them:
 >
@@ -59,7 +59,7 @@ cd civicrecords-ai
 .\install.ps1
 ```
 
-**macOS / Linux:**
+**macOS / Linux** (script path; not lifecycle-certified — see "Supported Platforms" below)**:**
 ```bash
 git clone https://github.com/CivicSuite/civicrecords-ai.git
 cd civicrecords-ai
@@ -176,7 +176,7 @@ Docker deployments; those names are recoverable with `docker exec env`.
 ## Supported Platforms
 
 - Windows 10/11 (Docker Desktop)
-- macOS 13+ (Docker Desktop)
+- macOS 13+ (Docker Desktop) — Windows-only currently; macOS support pending lifecycle certification (script-path install only)
 - Ubuntu 22.04+ / Debian 12+ (Docker Engine)
 
 All platforms use identical Docker containers — the application runs in Linux containers regardless of host OS.

--- a/README.txt
+++ b/README.txt
@@ -33,7 +33,7 @@ No open-source tool exists for the **responder side** of open records at the mun
 
 ### Requirements
 
-- **Docker Desktop** (Windows 10/11, macOS 13+) or **Docker Engine** (Linux)
+- **Docker Desktop** (Windows 10/11) or **Docker Engine** (Linux). Windows-only currently; macOS support pending lifecycle certification (Docker Desktop on macOS 13+ runs the script path but is not lifecycle-certified).
 - **8+ CPU cores**, **32 GB RAM**, **50 GB free disk space**
 - No internet connection required after initial setup
 
@@ -43,7 +43,7 @@ No open-source tool exists for the **responder side** of open records at the mun
 >
 > 1. **Windows double-click installer (T5E, UNSIGNED).** A signed build is a future release — this one is not. The unsigned installer is published on every release tag at `releases/download/<tag>/CivicRecordsAI-<version>-Setup.exe` along with a SHA-256 checksum for independent verification. On first run Windows SmartScreen shows **"Windows protected your PC — Unknown publisher."** This is expected. Click **More info → Run anyway** to proceed. See [installer/windows/README.md](installer/windows/README.md) for the full SmartScreen walkthrough and checksum-verify steps. The installer bundles the repo snapshot, runs a prereq check (Docker Desktop, WSL 2 + Virtual Machine Platform, 32 GB RAM floor, optional host Ollama), then runs `install.ps1` (via `installer\windows\launch-install.ps1`). `install.ps1` **auto-pulls `nomic-embed-text` and auto-pulls the Gemma 4 tag you select in the picker** (default `gemma4:e4b`) — expect several minutes on first run — and seeds the T5B baseline datasets.
 >
-> 2. **Script-based install (Linux / macOS, and Windows if you prefer CLI).** The scripts below configure and start the Docker Compose stack. They do **not** install Docker, WSL, or any other system prerequisites — those must already be present. `install.ps1` / `install.sh` both ship the 4-model Gemma 4 picker, auto-pull the selected LLM plus `nomic-embed-text`, and auto-seed the baseline datasets on first boot.
+> 2. **Script-based install (Linux / macOS — not lifecycle-certified — and Windows if you prefer CLI).** Windows-only currently; macOS support pending lifecycle certification. The scripts below configure and start the Docker Compose stack on macOS and Linux as a non-certified path, and on Windows as a CLI alternative. They do **not** install Docker, WSL, or any other system prerequisites — those must already be present. `install.ps1` / `install.sh` both ship the 4-model Gemma 4 picker, auto-pull the selected LLM plus `nomic-embed-text`, and auto-seed the baseline datasets on first boot.
 >
 > **Two shortcuts, two flows.** The Windows installer creates **separate** Start Menu entries for the two operations — don't confuse them:
 >
@@ -59,7 +59,7 @@ cd civicrecords-ai
 .\install.ps1
 ```
 
-**macOS / Linux:**
+**macOS / Linux** (script path; not lifecycle-certified — see "Supported Platforms" below)**:**
 ```bash
 git clone https://github.com/CivicSuite/civicrecords-ai.git
 cd civicrecords-ai
@@ -176,7 +176,7 @@ Docker deployments; those names are recoverable with `docker exec env`.
 ## Supported Platforms
 
 - Windows 10/11 (Docker Desktop)
-- macOS 13+ (Docker Desktop)
+- macOS 13+ (Docker Desktop) — Windows-only currently; macOS support pending lifecycle certification (script-path install only)
 - Ubuntu 22.04+ / Debian 12+ (Docker Engine)
 
 All platforms use identical Docker containers — the application runs in Linux containers regardless of host OS.

--- a/USER-MANUAL.md
+++ b/USER-MANUAL.md
@@ -256,8 +256,8 @@ This means the system lost connection to that data source after repeated failure
 | CPU | 8 cores | 16 cores |
 | RAM | 32 GB | 64 GB |
 | Disk | 50 GB free | 2+ TB NVMe |
-| OS | Windows 10/11, macOS 13+, Ubuntu 22.04+, Debian 12+ | Ubuntu 22.04 LTS |
-| Runtime | Docker Desktop (Windows/macOS) or Docker Engine (Linux) | Docker Engine 24+ |
+| OS | Windows 10/11 (lifecycle-certified). macOS 13+, Ubuntu 22.04+, Debian 12+ on script path (not lifecycle-certified) — Windows-only currently; macOS support pending lifecycle certification. | Ubuntu 22.04 LTS |
+| Runtime | Docker Desktop on Windows (lifecycle-certified) or macOS (not lifecycle-certified) or Docker Engine (Linux) | Docker Engine 24+ |
 
 **GPU (optional but recommended):**
 - NVIDIA (CUDA) — Windows and Linux
@@ -274,13 +274,13 @@ There are two supported install paths. Pick the one that matches your platform a
 > **Install paths currently shipped:**
 >
 > 1. **Windows double-click installer (T5E, UNSIGNED).** A real `.exe` installer built with Inno Setup 6.x is produced on every `v*` tag and published to GitHub Releases as `CivicRecordsAI-<version>-Setup.exe`. **It is unsigned by design for this release** (Scott-locked B3=α posture) — Windows SmartScreen will show "Windows protected your PC — Unknown publisher." on first run. Click **More info → Run anyway** to proceed. A SHA-256 checksum is published alongside each release asset for independent verification. The installer bundles the repo snapshot, runs a prerequisite check (Docker Desktop, WSL 2 + Virtual Machine Platform, 32 GB RAM floor, optional host Ollama), then runs `install.ps1` through `launch-install.ps1`. See [`installer/windows/README.md`](installer/windows/README.md) for the full SmartScreen walkthrough, the split Start/Install shortcut model, and checksum-verify steps.
-> 2. **Script-based install (macOS / Linux — and Windows if you prefer CLI).** The scripts below configure and launch the Docker Compose stack. They do **not** install Docker Desktop, Docker Engine, WSL, or any other system prerequisite — those must be present before the scripts run. If Docker is not installed, the scripts fail with a clear error and you must install Docker manually before retrying.
+> 2. **Script-based install (macOS / Linux — not lifecycle-certified — and Windows if you prefer CLI).** Windows-only currently; macOS support pending lifecycle certification. The scripts below configure and launch the Docker Compose stack on macOS and Linux as a non-certified path, and on Windows as a CLI alternative. They do **not** install Docker Desktop, Docker Engine, WSL, or any other system prerequisite — those must be present before the scripts run. If Docker is not installed, the scripts fail with a clear error and you must install Docker manually before retrying.
 >
-> **Cross-platform parity:** No native installer ships for macOS or Linux. That parity is explicit follow-on work and is not scheduled. macOS and Linux operators use the script path below.
+> **Cross-platform parity:** Windows-only currently; macOS support pending lifecycle certification. No native installer ships for macOS or Linux — that parity is explicit follow-on work and is not scheduled. macOS and Linux operators use the script path below, which is not lifecycle-certified.
 
 **Before you begin — prerequisites:**
 
-1. Install **Docker Desktop** (Windows 10/11 or macOS 13+): [docker.com/get-started](https://www.docker.com/get-started)
+1. Install **Docker Desktop** (Windows 10/11; macOS 13+ supported on the script path but Windows-only currently — macOS support pending lifecycle certification): [docker.com/get-started](https://www.docker.com/get-started)
    *Linux:* Install **Docker Engine** 24+ and Docker Compose v2.
 2. Ensure Docker is running (you should see the Docker icon in your taskbar/menu bar, or `docker info` returns without error).
 3. Confirm system requirements: 8+ CPU cores, 32 GB RAM, 50 GB free disk.
@@ -294,7 +294,7 @@ cd civicrecords-ai
 .\install.ps1
 ```
 
-**macOS / Linux:**
+**macOS / Linux** (script path; not lifecycle-certified — see B.1 System Requirements)**:**
 ```bash
 git clone https://github.com/CivicSuite/civicrecords-ai.git
 cd civicrecords-ai

--- a/USER-MANUAL.txt
+++ b/USER-MANUAL.txt
@@ -256,8 +256,8 @@ This means the system lost connection to that data source after repeated failure
 | CPU | 8 cores | 16 cores |
 | RAM | 32 GB | 64 GB |
 | Disk | 50 GB free | 2+ TB NVMe |
-| OS | Windows 10/11, macOS 13+, Ubuntu 22.04+, Debian 12+ | Ubuntu 22.04 LTS |
-| Runtime | Docker Desktop (Windows/macOS) or Docker Engine (Linux) | Docker Engine 24+ |
+| OS | Windows 10/11 (lifecycle-certified). macOS 13+, Ubuntu 22.04+, Debian 12+ on script path (not lifecycle-certified) — Windows-only currently; macOS support pending lifecycle certification. | Ubuntu 22.04 LTS |
+| Runtime | Docker Desktop on Windows (lifecycle-certified) or macOS (not lifecycle-certified) or Docker Engine (Linux) | Docker Engine 24+ |
 
 **GPU (optional but recommended):**
 - NVIDIA (CUDA) — Windows and Linux
@@ -274,13 +274,13 @@ There are two supported install paths. Pick the one that matches your platform a
 > **Install paths currently shipped:**
 >
 > 1. **Windows double-click installer (T5E, UNSIGNED).** A real `.exe` installer built with Inno Setup 6.x is produced on every `v*` tag and published to GitHub Releases as `CivicRecordsAI-<version>-Setup.exe`. **It is unsigned by design for this release** (Scott-locked B3=α posture) — Windows SmartScreen will show "Windows protected your PC — Unknown publisher." on first run. Click **More info → Run anyway** to proceed. A SHA-256 checksum is published alongside each release asset for independent verification. The installer bundles the repo snapshot, runs a prerequisite check (Docker Desktop, WSL 2 + Virtual Machine Platform, 32 GB RAM floor, optional host Ollama), then runs `install.ps1` through `launch-install.ps1`. See [`installer/windows/README.md`](installer/windows/README.md) for the full SmartScreen walkthrough, the split Start/Install shortcut model, and checksum-verify steps.
-> 2. **Script-based install (macOS / Linux — and Windows if you prefer CLI).** The scripts below configure and launch the Docker Compose stack. They do **not** install Docker Desktop, Docker Engine, WSL, or any other system prerequisite — those must be present before the scripts run. If Docker is not installed, the scripts fail with a clear error and you must install Docker manually before retrying.
+> 2. **Script-based install (macOS / Linux — not lifecycle-certified — and Windows if you prefer CLI).** Windows-only currently; macOS support pending lifecycle certification. The scripts below configure and launch the Docker Compose stack on macOS and Linux as a non-certified path, and on Windows as a CLI alternative. They do **not** install Docker Desktop, Docker Engine, WSL, or any other system prerequisite — those must be present before the scripts run. If Docker is not installed, the scripts fail with a clear error and you must install Docker manually before retrying.
 >
-> **Cross-platform parity:** No native installer ships for macOS or Linux. That parity is explicit follow-on work and is not scheduled. macOS and Linux operators use the script path below.
+> **Cross-platform parity:** Windows-only currently; macOS support pending lifecycle certification. No native installer ships for macOS or Linux — that parity is explicit follow-on work and is not scheduled. macOS and Linux operators use the script path below, which is not lifecycle-certified.
 
 **Before you begin — prerequisites:**
 
-1. Install **Docker Desktop** (Windows 10/11 or macOS 13+): [docker.com/get-started](https://www.docker.com/get-started)
+1. Install **Docker Desktop** (Windows 10/11; macOS 13+ supported on the script path but Windows-only currently — macOS support pending lifecycle certification): [docker.com/get-started](https://www.docker.com/get-started)
    *Linux:* Install **Docker Engine** 24+ and Docker Compose v2.
 2. Ensure Docker is running (you should see the Docker icon in your taskbar/menu bar, or `docker info` returns without error).
 3. Confirm system requirements: 8+ CPU cores, 32 GB RAM, 50 GB free disk.
@@ -294,7 +294,7 @@ cd civicrecords-ai
 .\install.ps1
 ```
 
-**macOS / Linux:**
+**macOS / Linux** (script path; not lifecycle-certified — see B.1 System Requirements)**:**
 ```bash
 git clone https://github.com/CivicSuite/civicrecords-ai.git
 cd civicrecords-ai

--- a/docs/github-discussions-seed.md
+++ b/docs/github-discussions-seed.md
@@ -67,7 +67,7 @@ CivicRecords AI is an open-source, locally-hosted AI system built for American c
 **Quick links:**
 - [README](../README.md) — quick start and feature overview
 - [User Manual](civicrecords-ai-manual.pdf) — staff operations guide + IT reference + architecture
-- [Installation](https://github.com/CivicSuite/civicrecords-ai#install) — one command on Windows, macOS, or Linux
+- [Installation](https://github.com/CivicSuite/civicrecords-ai#install) — Windows-only currently; macOS support pending lifecycle certification (macOS and Linux operators may use the `install.sh` script path, which is not lifecycle-certified)
 - [v1.4.0 Windows installer](https://github.com/CivicSuite/civicrecords-ai/releases/download/v1.4.0/CivicRecordsAI-1.4.0-Setup.exe) — direct download
 - [CHANGELOG](../CHANGELOG.md) — full history of every release
 
@@ -87,7 +87,7 @@ If you're a city clerk, records officer, IT administrator, or civic technologist
 
 **Minimum requirements:**
 - 8 CPU cores (16 recommended), 32 GB RAM (64 GB recommended), 50 GB free disk space
-- Docker Desktop (Windows 10/11 or macOS 13+) or Docker Engine (Ubuntu 20.04+, Debian 11+)
+- Docker Desktop (Windows 10/11; macOS 13+ supported on the script path but Windows-only currently — macOS support pending lifecycle certification) or Docker Engine (Ubuntu 20.04+, Debian 11+)
 - No internet connection required after initial setup
 
 **Installation — three steps:**
@@ -99,7 +99,7 @@ cd civicrecords-ai
 .\install.ps1
 ```
 
-*Linux / macOS:*
+*Linux / macOS* (script path; not lifecycle-certified — Windows-only currently, macOS support pending lifecycle certification)*:*
 ```bash
 git clone https://github.com/CivicSuite/civicrecords-ai.git
 cd civicrecords-ai


### PR DESCRIPTION
## Goal (from manifest)

> Sweep README, USER-MANUAL, FAQ, STATUS, and platform-matrix surfaces across
> the CivicSuite umbrella plus civicrecords-ai and civicclerk to replace
> unqualified macOS support claims with 'Windows-only currently; macOS support
> pending lifecycle certification,' honestly narrowing the published platform
> matrix to match actual lifecycle-certified support.

## Definition-of-done clause 1 (from manifest)

> Macos honest-narrowing is satisfied when (1) every unqualified macOS support
> claim across README/USER-MANUAL/FAQ/STATUS/SUPPORT and any platform-matrix-
> bearing markdown in CivicSuite/civicsuite, CivicSuite/civicrecords-ai, and
> CivicSuite/civicclerk has been replaced with 'Windows-only currently; macOS
> support pending lifecycle certification.' or a clearly-scoped equivalent.

## Files changed (civicrecords-ai)

- `README.md` — 4 edits: Requirements Docker Desktop bullet (L36),
  Script-based install paragraph (L46), `**macOS / Linux:**` install-block
  heading (L62), Supported Platforms macOS bullet (L179).
- `README.txt` — 4 edits: plain-text mirror of `README.md` at the same line
  numbers, satisfying definition-of-done clause (3) "plain-text mirrors
  (.txt) match their markdown counterparts where both exist."
- `USER-MANUAL.md` — 6 edits: B.1 System Requirements platform-matrix table
  OS row (L259) and Runtime row (L260), B.2 Script-based install paragraph
  (L277), Cross-platform parity callout (L279), Docker Desktop prerequisite
  step (L283), and the second `**macOS / Linux:**` install-block heading
  (L297).
- `USER-MANUAL.txt` — 6 edits: plain-text mirror of `USER-MANUAL.md` at the
  same line numbers.
- `docs/github-discussions-seed.md` — 3 edits: "one command on Windows,
  macOS, or Linux" parity claim (L70), Docker Desktop prereq (L90), and the
  italicized `*Linux / macOS:*` install-block heading (L102).

Total: 5 files, 23 edits, 0 code/test changes.

## Branch note

PR opens against `master` (this repo's default branch); the manifest used
"main" generically. Branch name `chore/macos-honest-narrowing` matches the
manifest's `target_repos[1].branch`.

## Autonomous-run context

Autonomous run under grant
[`candidate-b-macos-2026-05-13.md`](https://github.com/CivicSuite/civicsuite/blob/main/.agent-workflows/autonomous-grants/candidate-b-macos-2026-05-13.md).
Manifest:
[`.agent-runs/2026-05-13-macos-honest-narrowing/manifest.yaml`](https://github.com/CivicSuite/civicsuite/blob/main/.agent-runs/2026-05-13-macos-honest-narrowing/manifest.yaml)
(in the civicsuite umbrella repo).

**Not for admin-merge; awaiting human review.** The autonomous grant
explicitly forbids admin-merge and tag/release operations.

Run-id: `2026-05-13-macos-honest-narrowing`
Commit: `d275045`
