### PR TITLE
chore(ci): migrate Linux jobs to self-hosted runner (windows job unchanged)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   # -------------------------------------------------------------------------
   backend:
     name: Backend (pytest via docker compose)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 25
 
     steps:
@@ -194,7 +194,7 @@ jobs:
   # -------------------------------------------------------------------------
   bootstrap-failure:
     name: T2C bootstrap-failure smoke test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
 
     steps:
@@ -303,7 +303,7 @@ jobs:
   # -------------------------------------------------------------------------
   frontend:
     name: Frontend (vitest + build)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     defaults:
       run:
@@ -354,7 +354,7 @@ jobs:
 
   recovery-gates:
     name: Release recovery gates
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
 
     steps:
@@ -385,7 +385,7 @@ jobs:
   # -------------------------------------------------------------------------
   ruff:
     name: ruff (lint)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   preflight-release-provenance:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   preflight:
     name: Preflight release provenance fixtures
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -51,7 +51,7 @@ jobs:
 
   verify-release-linux:
     name: Verify release on Linux (compose + tests)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: preflight
     steps:
       - uses: actions/checkout@v6
@@ -248,7 +248,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     needs: [build-windows-installer]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Migrate Linux jobs to runs-on: [self-hosted, linux, x64]. The Windows installer build job in release.yml stays on windows-latest since there's no Windows self-hosted runner.

Files:
- ci.yml: 5 jobs migrated (backend, bootstrap-failure, frontend, recovery-gates, ruff)
- release.yml: 3 Linux jobs (preflight, verify-release-linux, create-release); build-windows-installer unchanged
- release-preflight.yml: 1 job

Runner: nvideablackwell-civicsuite-2404. ci.yml uses docker compose heavily — Docker 29.1.3 + Compose v2.40.3 installed on host.

Pattern verified on [CivicSuite/civicsuite#133](https://github.com/CivicSuite/civicsuite/pull/133).