### PR TITLE
test(installer): add records starter-set integration check

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Any computer with a modern web browser. Clerks open the server's URL — **`http
 >
 > **Docker Desktop and WSL 2** must be installed and running before either path; the installer detects their absence and prints concrete remediation, but does not install them for you.
 
+For the CivicSuite starter-set package, run `python scripts/check_starter_set_integration.py --umbrella-root ..\civicsuite --require-archives` from this repo to verify that CivicCore installs first, CivicRecords AI and CivicClerk are selectable, package workflow proof is required, and Linux/Windows starter-set archives exist.
+
 **Windows:**
 ```powershell
 git clone https://github.com/CivicSuite/civicrecords-ai.git

--- a/README.txt
+++ b/README.txt
@@ -70,6 +70,8 @@ Any computer with a modern web browser. Clerks open the server's URL — **`http
 >
 > **Docker Desktop and WSL 2** must be installed and running before either path; the installer detects their absence and prints concrete remediation, but does not install them for you.
 
+For the CivicSuite starter-set package, run `python scripts/check_starter_set_integration.py --umbrella-root ..\civicsuite --require-archives` from this repo to verify that CivicCore installs first, CivicRecords AI and CivicClerk are selectable, package workflow proof is required, and Linux/Windows starter-set archives exist.
+
 **Windows:**
 ```powershell
 git clone https://github.com/CivicSuite/civicrecords-ai.git

--- a/backend/tests/test_starter_set_integration_helper.py
+++ b/backend/tests/test_starter_set_integration_helper.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import subprocess
 
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get("CIVICRECORDS_REPO_ROOT", Path(__file__).resolve().parents[2]))
 
 
 def _write_umbrella_fixture(root: Path) -> None:

--- a/backend/tests/test_starter_set_integration_helper.py
+++ b/backend/tests/test_starter_set_integration_helper.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_umbrella_fixture(root: Path) -> None:
+    installer = root / "installer"
+    dist = installer / "dist"
+    docs = root / "docs" / "installer"
+    dist.mkdir(parents=True)
+    docs.mkdir(parents=True)
+    (installer / "modules.json").write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "id": "clerk-core",
+                        "modules": ["civiccore", "civicrecords-ai", "civicclerk"],
+                    }
+                ],
+                "modules": [
+                    {"id": "civiccore", "current_version": "1.1.0", "selectable": False},
+                    {
+                        "id": "civicrecords-ai",
+                        "current_version": "1.6.1",
+                        "selectable": True,
+                        "civiccore_requirement": "1.0.1",
+                        "dependencies": ["civiccore"],
+                    },
+                    {
+                        "id": "civicclerk",
+                        "current_version": "1.0.1",
+                        "selectable": True,
+                        "dependencies": ["civiccore"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (docs / "starter-set-release-contract.md").write_text(
+        "\n".join(
+            [
+                "CivicRecords AI reports v1.6.1",
+                "CivicClerk reports v1.0.1 with CivicCore v1.0.1",
+                "--staff-mode bearer --workflow-proof",
+                "Package Cleanroom Contract",
+                "workflow_proof_requested=true",
+                "not yet a claim that CivicRecords AI and CivicClerk exchange workflow records",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (dist / "CivicSuite-clerk-core-linux-0.1.0.tar.gz").write_text("linux\n", encoding="utf-8")
+    (dist / "CivicSuite-clerk-core-windows-0.1.0.zip").write_text("windows\n", encoding="utf-8")
+
+
+def test_starter_set_integration_passes_with_umbrella_contract(tmp_path: Path) -> None:
+    _write_umbrella_fixture(tmp_path)
+    report = tmp_path / "starter-set.json"
+
+    result = subprocess.run(
+        [
+            "python",
+            "scripts/check_starter_set_integration.py",
+            "--umbrella-root",
+            str(tmp_path),
+            "--require-archives",
+            "--output",
+            str(report),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "starter_set_ready=true" in result.stdout
+    assert "release_evidence_ready=true" in result.stdout
+    assert "[PASS] clerk-core profile order" in result.stdout
+    assert "[PASS] CivicRecords AI module contract" in result.stdout
+    assert "[PASS] CivicClerk pairing" in result.stdout
+    assert "[PASS] starter-set release contract" in result.stdout
+    assert "[PASS] starter-set archives" in result.stdout
+    assert "STARTER-SET-INTEGRATION: RELEASE-EVIDENCE-READY" in result.stdout
+    assert '"release_evidence_ready": true' in report.read_text(encoding="utf-8")
+
+
+def test_starter_set_integration_print_only_documents_contract() -> None:
+    result = subprocess.run(
+        ["python", "scripts/check_starter_set_integration.py", "--print-only"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Umbrella clerk-core profile installs CivicCore" in result.stdout
+    assert "package workflow proof" in result.stdout
+    assert "STARTER-SET-INTEGRATION: PLAN" in result.stdout
+
+
+def test_starter_set_integration_fails_when_manifest_is_missing(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            "python",
+            "scripts/check_starter_set_integration.py",
+            "--umbrella-root",
+            str(tmp_path),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "[FAIL] umbrella checkout" in result.stdout
+    assert "STARTER-SET-INTEGRATION: FAILED" in result.stdout

--- a/docs/ops/starter-set-integration.md
+++ b/docs/ops/starter-set-integration.md
@@ -1,0 +1,29 @@
+# CivicRecords AI Starter-Set Integration
+
+Status: maintained module-side proof helper for the CivicCore + CivicRecords AI + CivicClerk starter set.
+
+The umbrella installer owns the generated starter-set packages. CivicRecords AI
+owns the module contract it contributes to that package: version, CivicCore
+runtime pin, selectability, and honest boundary language.
+
+Run the module-side check from this repo:
+
+```powershell
+python scripts\check_starter_set_integration.py --umbrella-root ..\civicsuite --require-archives
+```
+
+The check verifies that:
+
+- the umbrella `clerk-core` profile installs CivicCore first, then CivicRecords
+  AI, then CivicClerk;
+- CivicRecords AI is selectable at v1.6.1 and records the CivicCore 1.0.1
+  runtime dependency used by the current module release;
+- CivicClerk is paired at v1.0.1;
+- the umbrella release contract requires package workflow proof with
+  `--staff-mode bearer --workflow-proof`;
+- Linux and Windows starter-set release archives exist when
+  `--require-archives` is used.
+
+This is starter-set install/test evidence. It is not a claim that CivicRecords
+AI and CivicClerk exchange live workflow records through a cross-module
+business API yet, and it is not macOS lifecycle certification.

--- a/scripts/check_starter_set_integration.py
+++ b/scripts/check_starter_set_integration.py
@@ -1,0 +1,270 @@
+"""Verify CivicRecords AI's contract inside the CivicSuite starter-set installer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_UMBRELLA_ROOT = ROOT.parent / "civicsuite"
+EXPECTED_RECORDS_VERSION = "1.6.1"
+EXPECTED_CLERK_VERSION = "1.0.1"
+EXPECTED_CIVICCORE_RUNTIME = "1.0.1"
+
+
+@dataclass(frozen=True)
+class Check:
+    status: str
+    name: str
+    message: str
+    fix: str
+
+    def public_dict(self) -> dict[str, str]:
+        return {
+            "status": self.status,
+            "name": self.name,
+            "message": self.message,
+            "fix": self.fix,
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check CivicRecords AI's CivicSuite starter-set installer contract."
+    )
+    parser.add_argument(
+        "--umbrella-root",
+        default=str(DEFAULT_UMBRELLA_ROOT),
+        help="Path to the sibling civicsuite umbrella checkout.",
+    )
+    parser.add_argument("--output", help="Optional JSON report path.")
+    parser.add_argument(
+        "--require-archives",
+        action="store_true",
+        help="Fail unless the generated Linux and Windows starter-set archives exist.",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print the starter-set integration plan without reading the umbrella checkout.",
+    )
+    return parser.parse_args()
+
+
+def _pass(name: str, message: str) -> Check:
+    return Check(status="PASS", name=name, message=message, fix="No action required.")
+
+
+def _fail(name: str, message: str, fix: str) -> Check:
+    return Check(status="FAIL", name=name, message=message, fix=fix)
+
+
+def _load_json(path: Path) -> dict[str, object] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def build_checks(*, umbrella_root: Path, require_archives: bool) -> list[Check]:
+    manifest = _load_json(umbrella_root / "installer" / "modules.json")
+    if manifest is None:
+        return [
+            _fail(
+                "umbrella checkout",
+                "missing umbrella installer manifest",
+                "Pass --umbrella-root pointing to the civicsuite checkout before using this as release evidence.",
+            )
+        ]
+
+    profiles = {str(item.get("id")): item for item in manifest.get("profiles", []) if isinstance(item, dict)}
+    modules = {str(item.get("id")): item for item in manifest.get("modules", []) if isinstance(item, dict)}
+
+    clerk_core = profiles.get("clerk-core")
+    if isinstance(clerk_core, dict) and clerk_core.get("modules") == [
+        "civiccore",
+        "civicrecords-ai",
+        "civicclerk",
+    ]:
+        checks = [
+            _pass(
+                "clerk-core profile order",
+                "clerk-core installs CivicCore first, then CivicRecords AI, then CivicClerk.",
+            )
+        ]
+    else:
+        checks = [
+            _fail(
+                "clerk-core profile order",
+                "clerk-core profile does not resolve to civiccore, civicrecords-ai, civicclerk.",
+                "Fix civicsuite/installer/modules.json before publishing CivicRecords AI as a starter-set module.",
+            )
+        ]
+
+    records = modules.get("civicrecords-ai")
+    if isinstance(records, dict) and (
+        records.get("selectable") is True
+        and records.get("current_version") == EXPECTED_RECORDS_VERSION
+        and records.get("civiccore_requirement") == EXPECTED_CIVICCORE_RUNTIME
+        and "civiccore" in records.get("dependencies", [])
+    ):
+        checks.append(
+            _pass(
+                "CivicRecords AI module contract",
+                f"CivicRecords AI is selectable at v{EXPECTED_RECORDS_VERSION} and depends on CivicCore {EXPECTED_CIVICCORE_RUNTIME}.",
+            )
+        )
+    else:
+        checks.append(
+            _fail(
+                "CivicRecords AI module contract",
+                "CivicRecords AI manifest entry does not match its version, selectability, or CivicCore dependency.",
+                "Update the umbrella module manifest and rerun installer verification.",
+            )
+        )
+
+    clerk = modules.get("civicclerk")
+    if isinstance(clerk, dict) and clerk.get("current_version") == EXPECTED_CLERK_VERSION:
+        checks.append(
+            _pass(
+                "CivicClerk pairing",
+                f"starter set pairs CivicRecords AI with CivicClerk {EXPECTED_CLERK_VERSION}.",
+            )
+        )
+    else:
+        checks.append(
+            _fail(
+                "CivicClerk pairing",
+                "starter set does not record the expected CivicClerk pairing.",
+                "Update the umbrella manifest or this checker before changing the starter-set pair.",
+            )
+        )
+
+    contract_path = umbrella_root / "docs" / "installer" / "starter-set-release-contract.md"
+    if contract_path.is_file():
+        text = contract_path.read_text(encoding="utf-8")
+        required_phrases = (
+            "CivicRecords AI reports v1.6.1",
+            "CivicClerk reports v1.0.1 with CivicCore v1.0.1",
+            "--staff-mode bearer --workflow-proof",
+            "Package Cleanroom Contract",
+            "workflow_proof_requested=true",
+            "not yet a claim that CivicRecords AI and CivicClerk exchange workflow records",
+        )
+        missing = [phrase for phrase in required_phrases if phrase not in text]
+        if missing:
+            checks.append(
+                _fail(
+                    "starter-set release contract",
+                    "release contract is missing: " + ", ".join(missing),
+                    "Restore the umbrella starter-set release contract before relying on Records installer evidence.",
+                )
+            )
+        else:
+            checks.append(
+                _pass(
+                    "starter-set release contract",
+                    "umbrella release contract records Records health, workflow proof, and current live-exchange boundary.",
+                )
+            )
+    else:
+        checks.append(
+            _fail(
+                "starter-set release contract",
+                f"missing {contract_path}",
+                "Add docs/installer/starter-set-release-contract.md to the umbrella repo.",
+            )
+        )
+
+    archive_paths = (
+        umbrella_root / "installer" / "dist" / "CivicSuite-clerk-core-linux-0.1.0.tar.gz",
+        umbrella_root / "installer" / "dist" / "CivicSuite-clerk-core-windows-0.1.0.zip",
+    )
+    missing_archives = [path.name for path in archive_paths if not path.is_file()]
+    if missing_archives and require_archives:
+        checks.append(
+            _fail(
+                "starter-set archives",
+                "missing generated release archives: " + ", ".join(missing_archives),
+                "Run the umbrella installer artifact generator and rerun this check.",
+            )
+        )
+    elif missing_archives:
+        checks.append(
+            Check(
+                status="WARN",
+                name="starter-set archives",
+                message="generated release archives are not present in this checkout: " + ", ".join(missing_archives),
+                fix="Use --require-archives for release evidence; warning-only is acceptable in source-only CI.",
+            )
+        )
+    else:
+        checks.append(_pass("starter-set archives", "Linux and Windows starter-set release archives are present."))
+
+    return checks
+
+
+def _payload(checks: list[Check], umbrella_root: Path) -> dict[str, object]:
+    return {
+        "product": "CivicRecords AI",
+        "version": EXPECTED_RECORDS_VERSION,
+        "umbrella_root": str(umbrella_root),
+        "starter_set_ready": all(check.status in {"PASS", "WARN"} for check in checks),
+        "release_evidence_ready": all(check.status == "PASS" for check in checks),
+        "civiccore_runtime": EXPECTED_CIVICCORE_RUNTIME,
+        "civicclerk_pair": EXPECTED_CLERK_VERSION,
+        "checks": [check.public_dict() for check in checks],
+    }
+
+
+def _print_report(checks: list[Check], umbrella_root: Path) -> None:
+    payload = _payload(checks, umbrella_root)
+    print("CivicRecords AI starter-set integration")
+    print(f"Version: {EXPECTED_RECORDS_VERSION}")
+    print(f"Umbrella root: {umbrella_root}")
+    print(f"starter_set_ready={str(payload['starter_set_ready']).lower()}")
+    print(f"release_evidence_ready={str(payload['release_evidence_ready']).lower()}")
+    for check in checks:
+        print(f"[{check.status}] {check.name}: {check.message}")
+        print(f"  fix: {check.fix}")
+    if payload["release_evidence_ready"]:
+        print("STARTER-SET-INTEGRATION: RELEASE-EVIDENCE-READY")
+    elif payload["starter_set_ready"]:
+        print("STARTER-SET-INTEGRATION: SOURCE-READY")
+    else:
+        print("STARTER-SET-INTEGRATION: FAILED")
+
+
+def _print_plan() -> None:
+    print("CivicRecords AI starter-set integration")
+    print("Release evidence checks:")
+    print("  1. Umbrella clerk-core profile installs CivicCore, CivicRecords AI, then CivicClerk.")
+    print("  2. CivicRecords AI is selectable and records its CivicCore 1.0.1 runtime dependency.")
+    print("  3. CivicClerk is paired at v1.0.1.")
+    print("  4. Umbrella release contract requires package workflow proof.")
+    print("  5. Linux and Windows starter-set archives exist when --require-archives is used.")
+    print("STARTER-SET-INTEGRATION: PLAN")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.print_only:
+        _print_plan()
+        return 0
+    umbrella_root = Path(args.umbrella_root).resolve()
+    checks = build_checks(umbrella_root=umbrella_root, require_archives=args.require_archives)
+    payload = _payload(checks, umbrella_root)
+    if args.output:
+        Path(args.output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _print_report(checks, umbrella_root)
+    return 0 if payload["starter_set_ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-recovery-gates.py
+++ b/scripts/verify-recovery-gates.py
@@ -18,6 +18,8 @@ REQUIRED_FILES = [
     "frontend/e2e/civicrecords-user-flows.spec.ts",
     "scripts/verify-secret-scan.py",
     "scripts/verify-runtime-install.py",
+    "scripts/check_starter_set_integration.py",
+    "docs/ops/starter-set-integration.md",
 ]
 
 OVERCLAIM_PATTERNS = [


### PR DESCRIPTION
## Summary
- adds a CivicRecords AI-side starter-set checker for the umbrella `clerk-core` installer profile
- verifies CivicCore-first order, Records selectability/version/runtime pin, CivicClerk pairing, package workflow-proof contract language, and Linux/Windows archive presence when requested
- documents and recovery-gates the checker, with focused tests for release-ready, print-only, and missing-manifest paths

## Verification
- `python -m py_compile scripts\check_starter_set_integration.py scripts\verify-recovery-gates.py`
- `python -m pytest backend\tests\test_starter_set_integration_helper.py`
- `python scripts\verify-recovery-gates.py`
- `git diff --check`
- `python scripts\check_starter_set_integration.py --umbrella-root ..\civicsuite --require-archives --output .agent-runs\starter-set-integration-records-20260515.json`