### PR TITLE
fix: align release workflow CivicCore provenance to v1.2.0

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -49,12 +49,12 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install CivicCore release-provenance helper
-        run: python -m pip install "git+https://github.com/CivicSuite/civiccore.git@main"
+        run: python -m pip install https://github.com/CivicSuite/civiccore/releases/download/v1.2.0/civiccore-1.2.0-py3-none-any.whl
       - name: Checkout canonical CivicCore provenance fixtures
         uses: actions/checkout@v6
         with:
           repository: CivicSuite/civiccore
-          ref: main
+          ref: v1.2.0
           path: .tmp-civiccore
       - name: Verify adversarial release provenance fixtures
         run: python scripts/verify-release-provenance.py --fixtures-dir .tmp-civiccore/tests/fixtures/release_provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,13 @@ jobs:
           python-version: "3.13"
 
       - name: Install CivicCore release-provenance helper
-        run: python -m pip install "git+https://github.com/CivicSuite/civiccore.git@main"
+        run: python -m pip install https://github.com/CivicSuite/civiccore/releases/download/v1.2.0/civiccore-1.2.0-py3-none-any.whl
 
       - name: Checkout canonical CivicCore provenance fixtures
         uses: actions/checkout@v6
         with:
           repository: CivicSuite/civiccore
-          ref: main
+          ref: v1.2.0
           path: .tmp-civiccore
 
       - name: Verify adversarial release provenance fixtures
@@ -64,7 +64,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install CivicCore release-provenance helper
-        run: python -m pip install "git+https://github.com/CivicSuite/civiccore.git@main"
+        run: python -m pip install https://github.com/CivicSuite/civiccore/releases/download/v1.2.0/civiccore-1.2.0-py3-none-any.whl
 
       - name: Synthesize hermetic .env for release verification
         shell: bash
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install CivicCore release-provenance helper
         shell: bash
-        run: python -m pip install "git+https://github.com/CivicSuite/civiccore.git@main"
+        run: python -m pip install https://github.com/CivicSuite/civiccore/releases/download/v1.2.0/civiccore-1.2.0-py3-none-any.whl
 
       - name: Install Inno Setup
         run: choco install innosetup -y


### PR DESCRIPTION
## Summary
- replace mutable/stale CivicCore provenance helper refs in release workflows with the published v1.2.0 wheel
- checkout CivicCore provenance fixtures from v1.2.0 instead of main

## Verification
- git diff --check
- stale release-workflow ref scan for civiccore.git@main/v1.0 and ref main/v1.0 returned no hits

This must land before tagging v1.7.0.