### PR TITLE
fix: shallow checkout windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          ref: ${{ github.ref }}
 
       - name: Set up Python for release provenance preflight
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- narrow the Windows installer release checkout to the triggering tag ref
- avoid all-ref fetches on the Windows runner that failed before artifact build

## Verification
- git diff --check

Release-train scope: CivicRecords AI v1.7.0 release workflow repair only; no product code changes.