### PR TITLE
test: lock cleanroom release workflow contract

### DIFF
--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import yaml
+
+
+RELEASE_WORKFLOW = Path(".github/workflows/release.yml")
+
+
+def _workflow() -> dict:
+    data = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML 1.1 treats the key "on" as boolean True.
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def test_release_workflow_dispatch_release_tag_contract() -> None:
+    workflow = _workflow()
+    workflow_dispatch = _triggers(workflow)["workflow_dispatch"]
+    release_tag = workflow_dispatch["inputs"]["release_tag"]
+
+    assert release_tag["required"] is True
+    assert release_tag["default"] == "v1.7.3"
+
+
+def test_release_workflow_cleanroom_release_gate_contract() -> None:
+    workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    release_notes_template = Path(".github/release-notes-v15-template.md").read_text(
+        encoding="utf-8"
+    )
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+
+    assert jobs["publish-release"]["needs"] == ["release-cleanroom-rehearsal"]
+    assert "release-cleanroom-rehearsal" in jobs
+    assert "civicsuite-cleanroom=1" in workflow_text
+    assert "system prune" not in workflow_text
+    assert (
+        "Cleanroom rehearsal: PASSED in workflow run ${WORKFLOW_RUN_ID}"
+        in release_notes_template
+    )
+    assert "Verified clean install of ${WHEEL_URL} from cold caches" in release_notes_template


### PR DESCRIPTION
## Summary
- Adds a workflow contract test for the release cleanroom gate.
- Locks the required workflow_dispatch release_tag input at v1.7.3.
- Asserts publish-release depends on release-cleanroom-rehearsal, scoped cleanroom labels are present, unscoped system prune is absent, and the cleanroom annotation template is present.

## Verification
- `python -m pytest tests/test_github_workflows.py -v` -> 2 passed, 1 warning.
- Mutation proof: temporarily removed `publish-release.needs`; `python -m pytest tests/test_github_workflows.py -v` failed with KeyError on `needs`; restored and reran to pass.
- Step 2.5 baseline isolation: current `origin/master` verifier is already red before this PR (sovereignty guard, ruff, pytest collect/full). This PR is test-only and does not change runtime code or release workflow behavior.

## Caveats
- Pre-existing untracked browser-QA temp directories remain local and are not part of this PR.