### PR TITLE
Ignore generated browser QA artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Thumbs.db
 
 # Temp files
 temp_*.tsx
+.tmp-browser-qa-*/
 
 # Hardware detection output
 .env.hardware


### PR DESCRIPTION
## Summary
- Ignore generated browser QA temp directories produced during local QA runs.

## Verification
- `git diff --check`
- `git check-ignore -v '.tmp-browser-qa-proof/example.txt'` returned `.gitignore:40:.tmp-browser-qa-*/`
- Documentation gate checked: README.md, CHANGELOG.md, CONTRIBUTING.md, LICENSE, .gitignore, docs/index.html all exist.

## Notes
No runtime code or release behavior changes.