### PR TITLE
fix(compose): let api/worker boot without ollama health gate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      ollama:
-        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
       interval: 15s
@@ -76,8 +74,6 @@ services:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_healthy
-      ollama:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "celery -A app.worker inspect ping || exit 1"]

--- a/tests/test_soft_ai_dependency_compose.py
+++ b/tests/test_soft_ai_dependency_compose.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _compose_service(compose: str, service_name: str, next_service: str) -> str:
+    return compose.split(f"  {service_name}:", 1)[1].split(f"  {next_service}:", 1)[0]
+
+
+def test_api_and_worker_do_not_wait_on_ollama_health_to_boot() -> None:
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    api_service = _compose_service(compose, "api", "worker")
+    worker_service = _compose_service(compose, "worker", "beat")
+
+    assert "ollama/ollama:latest" in compose
+    for service in (api_service, worker_service):
+        depends_on = service.split("depends_on:", 1)[1].split("healthcheck:", 1)[0]
+        assert "postgres:" in depends_on
+        assert "redis:" in depends_on
+        assert "condition: service_healthy" in depends_on
+        assert "ollama:" not in depends_on


### PR DESCRIPTION
Removes ollama service_healthy gate from base-compose api+worker so services boot without the LLM (mirror of the CivicClerk soft-AI fix). Host-ollama topology already had no such gate. Independently audited by Claude: compose-contract test passes.

Signed-off-by: Codex <codex@openai.com>